### PR TITLE
feat(be): versioning

### DIFF
--- a/apps/backend/src/constants/swagger.const.ts
+++ b/apps/backend/src/constants/swagger.const.ts
@@ -14,4 +14,10 @@ Thank you for checking out my project.
 - [GraphQL Playground](${GRAPHQL_PATH})
 - [Swagger JSON file](${SWAGGER_JSON_PATH})
 - [Source code](${SOURCE_CODE_URL})
+
+### ⚠️ Warning
+Do __NOT__ use non-versioned endpoints (e.g. \`/stop/all\`). Use versioned endpoints instead (e.g. \`/v1/stop/all\`).
+
+Non-versioned endpoints are deprecated and will be removed in the future.
+
 `;

--- a/apps/backend/src/enums/endpoint-version.ts
+++ b/apps/backend/src/enums/endpoint-version.ts
@@ -1,0 +1,3 @@
+export enum EndpointVersion {
+    v1 = "1",
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,4 +1,5 @@
 import { SWAGGER_JSON_PATH, SWAGGER_PATH } from "@metro-now/constants";
+import { VersioningType } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
@@ -17,6 +18,11 @@ async function bootstrap() {
 
     app.useLogger(new LoggerService());
     app.enableCors();
+
+    app.enableVersioning({
+        type: VersioningType.URI,
+        prefix: "v",
+    });
 
     const swaggerDocumentBuilder = new DocumentBuilder()
         .setTitle(SWAGGER_TITLE)

--- a/apps/backend/src/modules/departure/departure.controller.ts
+++ b/apps/backend/src/modules/departure/departure.controller.ts
@@ -6,12 +6,15 @@ import {
     HttpStatus,
     Query,
     UseInterceptors,
+    Version,
+    VERSION_NEUTRAL,
 } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 
 import { QUERY_IDS_COUNT_MAX } from "src/constants/constants";
 import { ApiQueries } from "src/decorators/swagger.decorator";
+import { EndpointVersion } from "src/enums/endpoint-version";
 import { DepartureService } from "src/modules/departure/departure.service";
 import {
     departureSchema,
@@ -30,6 +33,7 @@ export class DepartureController {
     constructor(private readonly departureService: DepartureService) {}
 
     @Get()
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     @ApiQueries([
         metroOnlyQuery,
         {
@@ -81,6 +85,7 @@ export class DepartureController {
     }
 
     @Get("/platform")
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     async getDeparturesByPlatform(@Query("id") id): Promise<DepartureSchema[]> {
         const platformSchema = z
             .string()

--- a/apps/backend/src/modules/platform/platform.controller.ts
+++ b/apps/backend/src/modules/platform/platform.controller.ts
@@ -6,11 +6,14 @@ import {
     HttpStatus,
     Query,
     UseInterceptors,
+    Version,
+    VERSION_NEUTRAL,
 } from "@nestjs/common";
 import { ApiQuery, ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 
 import { ApiDescription, ApiQueries } from "src/decorators/swagger.decorator";
+import { EndpointVersion } from "src/enums/endpoint-version";
 import { LogInterceptor } from "src/modules/logger/log.interceptor";
 import { PlatformService } from "src/modules/platform/platform.service";
 import {
@@ -37,6 +40,7 @@ export class PlatformController {
     constructor(private readonly platformService: PlatformService) {}
 
     @Get("/all")
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     @ApiDescription({
         summary: "List of all platforms",
     })
@@ -61,6 +65,7 @@ export class PlatformController {
     }
 
     @Get("/closest")
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     @ApiDescription({
         description: `
 ⚠️ _For better privacy consider using \`/in-box\`_
@@ -109,6 +114,7 @@ Sort platforms by distance to a given location. Location may be saved in logs.
     }
 
     @Get("/in-box")
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     @ApiDescription({
         summary: "List of platforms within a given bounding box",
     })

--- a/apps/backend/src/modules/status/status.controller.ts
+++ b/apps/backend/src/modules/status/status.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Version, VERSION_NEUTRAL } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import { ApiDescription } from "src/decorators/swagger.decorator";
@@ -15,6 +15,7 @@ export class StatusController {
     constructor(private readonly statusService: StatusService) {}
 
     @Get()
+    @Version([VERSION_NEUTRAL])
     @ApiDescription({
         summary: "Backend status",
     })
@@ -45,6 +46,7 @@ export class StatusController {
     }
 
     @Get("/geo-functions")
+    @Version([VERSION_NEUTRAL])
     @ApiDescription({ summary: "Geo functions status" })
     @ApiResponse({
         status: 200,
@@ -65,6 +67,7 @@ export class StatusController {
     }
 
     @Get("/db-data")
+    @Version([VERSION_NEUTRAL])
     @ApiDescription({ summary: "DB data status" })
     @ApiResponse({
         status: 200,

--- a/apps/backend/src/modules/stop/stop.controller.ts
+++ b/apps/backend/src/modules/stop/stop.controller.ts
@@ -1,7 +1,15 @@
 import { CacheInterceptor } from "@nestjs/cache-manager";
-import { Controller, Get, Query, UseInterceptors } from "@nestjs/common";
+import {
+    Controller,
+    Get,
+    Query,
+    UseInterceptors,
+    Version,
+    VERSION_NEUTRAL,
+} from "@nestjs/common";
 import { ApiQuery, ApiTags } from "@nestjs/swagger";
 
+import { EndpointVersion } from "src/enums/endpoint-version";
 import { LogInterceptor } from "src/modules/logger/log.interceptor";
 import { StopService } from "src/modules/stop/stop.service";
 import { metroOnlyQuery } from "src/swagger/query.swagger";
@@ -13,6 +21,7 @@ export class StopController {
     constructor(private readonly stopService: StopService) {}
 
     @Get("/all")
+    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
     @ApiQuery(metroOnlyQuery)
     async getAllStops(
         @Query("metroOnly")


### PR DESCRIPTION
## Changes

- endpoint versioning 


## Notes

> [!WARNING]
> - all endpoints are currently accessible with the prefix `v1/` and without the prefix
> - endpoints without a prefix will be deprecated in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
