### PR TITLE
refactor(be): remove deprecated endpoints

### DIFF
--- a/apps/backend/src/constants/swagger.const.ts
+++ b/apps/backend/src/constants/swagger.const.ts
@@ -14,10 +14,4 @@ Thank you for checking out my project.
 - [GraphQL Playground](${GRAPHQL_PATH})
 - [Swagger JSON file](${SWAGGER_JSON_PATH})
 - [Source code](${SOURCE_CODE_URL})
-
-### ⚠️ Warning
-Do __NOT__ use non-versioned endpoints (e.g. \`/stop/all\`). Use versioned endpoints instead (e.g. \`/v1/stop/all\`).
-
-Non-versioned endpoints are deprecated and will be removed in the future.
-
 `;

--- a/apps/backend/src/modules/departure/departure.controller.ts
+++ b/apps/backend/src/modules/departure/departure.controller.ts
@@ -7,13 +7,11 @@ import {
     Query,
     UseInterceptors,
     Version,
-    VERSION_NEUTRAL,
 } from "@nestjs/common";
-import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
 
-import { QUERY_IDS_COUNT_MAX } from "src/constants/constants";
-import { ApiDescription, ApiQueries } from "src/decorators/swagger.decorator";
+import { ApiQueries } from "src/decorators/swagger.decorator";
 import { EndpointVersion } from "src/enums/endpoint-version";
 import { DepartureServiceV1 } from "src/modules/departure/departure-v1.service";
 import { DepartureServiceV2 } from "src/modules/departure/departure-v2.service";
@@ -27,7 +25,6 @@ import {
     vehicleTypeSchema,
 } from "src/schema/metro-only.schema";
 import { metroOnlyQuery } from "src/swagger/query.swagger";
-import { toArray } from "src/utils/array.utils";
 
 @ApiTags("departure")
 @Controller("departure")
@@ -38,64 +35,6 @@ export class DepartureController {
         private readonly departureServiceV1: DepartureServiceV1,
         private readonly departureServiceV2: DepartureServiceV2,
     ) {}
-
-    @Get()
-    @Version([VERSION_NEUTRAL])
-    @ApiQueries([
-        metroOnlyQuery,
-        {
-            name: "platform[]",
-            description: "Platform IDs",
-            type: [String],
-            isArray: true,
-            allowEmptyValue: true,
-            required: false,
-        },
-        {
-            name: "stop[]",
-            description: "Stop IDs",
-            type: [String],
-            isArray: true,
-            allowEmptyValue: true,
-            required: false,
-        },
-    ])
-    @ApiOperation({
-        deprecated: true,
-    })
-    @ApiDescription({
-        deprecated: true,
-    })
-    async getDepartures(@Query() query): Promise<DepartureSchema[]> {
-        const schema = z.object({
-            metroOnly: metroOnlySchema,
-            platform: z.string().array().optional().default([]),
-            stop: z.string().array().optional().default([]),
-        });
-        const parsed = schema.safeParse(query);
-        if (!parsed.success) {
-            throw new HttpException(
-                "Invalid query params",
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-        const parsedQuery = parsed.data;
-
-        if (parsedQuery.platform.length + parsedQuery.stop.length === 0) {
-            throw new HttpException(
-                "At least one platform or stop ID must be provided",
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-
-        const departures = await this.departureServiceV1.getDepartures({
-            stopIds: parsedQuery.stop,
-            platformIds: parsedQuery.platform,
-            metroOnly: parsedQuery.metroOnly,
-        });
-
-        return departureSchema.array().parse(departures);
-    }
 
     @Get()
     @Version([EndpointVersion.v1])
@@ -144,35 +83,6 @@ export class DepartureController {
             stopIds: parsedQuery.stop,
             platformIds: parsedQuery.platform,
             metroOnly: parsedQuery.metroOnly,
-        });
-
-        return departureSchema.array().parse(departures);
-    }
-
-    @Get("/platform")
-    @Version([VERSION_NEUTRAL, EndpointVersion.v1])
-    @ApiDescription({
-        deprecated: true,
-    })
-    async getDeparturesByPlatform(@Query("id") id): Promise<DepartureSchema[]> {
-        const platformSchema = z
-            .string()
-            .array()
-            .min(1)
-            .max(QUERY_IDS_COUNT_MAX);
-        const parsed = platformSchema.safeParse(toArray(id));
-
-        if (!parsed.success) {
-            throw new HttpException(
-                "Invalid query params",
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-
-        const departures = await this.departureServiceV1.getDepartures({
-            stopIds: [],
-            platformIds: parsed.data,
-            metroOnly: false,
         });
 
         return departureSchema.array().parse(departures);

--- a/apps/backend/src/modules/platform/platform.controller.ts
+++ b/apps/backend/src/modules/platform/platform.controller.ts
@@ -7,7 +7,6 @@ import {
     Query,
     UseInterceptors,
     Version,
-    VERSION_NEUTRAL,
 } from "@nestjs/common";
 import { ApiQuery, ApiTags } from "@nestjs/swagger";
 import { z } from "zod";
@@ -40,32 +39,6 @@ export class PlatformController {
     constructor(private readonly platformService: PlatformService) {}
 
     @Get("/all")
-    @Version([VERSION_NEUTRAL])
-    @ApiDescription({
-        summary: "List of all platforms",
-        deprecated: true,
-    })
-    @ApiQuery(metroOnlyQuery)
-    async getAllPlatforms(@Query() query): Promise<PlatformSchema[]> {
-        const schema = z.object({
-            metroOnly: metroOnlySchema,
-        });
-        const parsed = schema.safeParse(query);
-        if (!parsed.success) {
-            throw new HttpException(
-                parsed.error.format(),
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-
-        const platforms = await this.platformService.getAllPlatforms(
-            parsed.data,
-        );
-
-        return platformSchema.array().parse(platforms);
-    }
-
-    @Get("/all")
     @Version([EndpointVersion.v1])
     @ApiDescription({
         summary: "List of all platforms",
@@ -88,56 +61,6 @@ export class PlatformController {
         );
 
         return platformSchema.array().parse(platforms);
-    }
-
-    @Get("/closest")
-    @Version([VERSION_NEUTRAL])
-    @ApiDescription({
-        description: `
-⚠️ _For better privacy consider using \`/in-box\`_
-
-
-Sort platforms by distance to a given location. Location may be saved in logs. 
-`,
-        summary: "List of platforms sorted by distance to a given location",
-        deprecated: true,
-    })
-    @ApiQueries([
-        metroOnlyQuery,
-        latitudeQuery,
-        longitudeQuery,
-        {
-            name: "count",
-            type: Number,
-            required: false,
-            example: 100,
-            description: "number of platforms to return, default is `0` (all)",
-        },
-    ])
-    async getPlatformsByDistance(
-        @Query() query,
-    ): Promise<PlatformWithDistanceSchema[]> {
-        const schema = z.object({
-            latitude: z.coerce.number(),
-            longitude: z.coerce.number(),
-            count: z.coerce.number().int().nonnegative().default(0),
-            metroOnly: metroOnlySchema,
-        });
-
-        const parsed = schema.safeParse(query);
-
-        if (!parsed.success) {
-            throw new HttpException(
-                parsed.error.format(),
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-
-        const platforms = await this.platformService.getPlatformsByDistance(
-            parsed.data,
-        );
-
-        return platformWithDistanceSchema.array().parse(platforms);
     }
 
     @Get("/closest")
@@ -187,40 +110,6 @@ Sort platforms by distance to a given location. Location may be saved in logs.
         );
 
         return platformWithDistanceSchema.array().parse(platforms);
-    }
-
-    @Get("/in-box")
-    @Version([VERSION_NEUTRAL])
-    @ApiDescription({
-        summary: "List of platforms within a given bounding box",
-        deprecated: true,
-    })
-    @ApiQueries([metroOnlyQuery, ...boundingBoxQuery])
-    async getPlatformsInBoundingBox(@Query() query): Promise<PlatformSchema[]> {
-        const schema = z.object({
-            boundingBox: boundingBoxSchema,
-            metroOnly: metroOnlySchema,
-        });
-        const parsed = schema.safeParse({
-            boundingBox: {
-                latitude: query?.latitude,
-                longitude: query?.longitude,
-            },
-            metroOnly: query?.metroOnly,
-        });
-
-        if (!parsed.success) {
-            throw new HttpException(
-                "Invalid query params",
-                HttpStatus.BAD_REQUEST,
-            );
-        }
-
-        const platforms = await this.platformService.getPlatformsInBoundingBox(
-            parsed.data,
-        );
-
-        return platformSchema.array().parse(platforms);
     }
 
     @Get("/in-box")

--- a/apps/backend/src/modules/stop/stop.controller.ts
+++ b/apps/backend/src/modules/stop/stop.controller.ts
@@ -8,11 +8,9 @@ import {
     Query,
     UseInterceptors,
     Version,
-    VERSION_NEUTRAL,
 } from "@nestjs/common";
 import { ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
 
-import { ApiDescription } from "src/decorators/swagger.decorator";
 import { EndpointVersion } from "src/enums/endpoint-version";
 import { LogInterceptor } from "src/modules/logger/log.interceptor";
 import { StopService } from "src/modules/stop/stop.service";
@@ -23,21 +21,6 @@ import { metroOnlyQuery } from "src/swagger/query.swagger";
 @UseInterceptors(CacheInterceptor, LogInterceptor)
 export class StopController {
     constructor(private readonly stopService: StopService) {}
-
-    @Get("/all")
-    @Version([VERSION_NEUTRAL])
-    @ApiQuery(metroOnlyQuery)
-    @ApiDescription({
-        deprecated: true,
-    })
-    async getAllStops(
-        @Query("metroOnly")
-        metroOnlyQuery: unknown,
-    ) {
-        const metroOnly: boolean = metroOnlyQuery === "true";
-
-        return this.stopService.getAll({ metroOnly });
-    }
 
     @Get("/all")
     @Version([EndpointVersion.v1])


### PR DESCRIPTION
## Changes
- remove endpoints without version prefix
- remove `/departure/platform` (it's been replaced by `/departure` with search params)

> [!WARNING]
> __BREAKING CHANGES__
> This PR should be merged after the majority of users update to the app version `0.3`