### PR TITLE
fix: missing departures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install -g corepack
 RUN corepack enable
 
 RUN apt-get update \

--- a/apps/backend/metro-now.postman_collection.json
+++ b/apps/backend/metro-now.postman_collection.json
@@ -1,0 +1,173 @@
+{
+    "info": {
+        "_postman_id": "ffce154e-3270-4344-a193-42344fcc19ae",
+        "name": "metro-now",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "_exporter_id": "16893880"
+    },
+    "item": [
+        {
+            "name": "departure",
+            "item": [
+                {
+                    "name": "stop",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{endpoint}}/v2/departure?stop[]=U1072",
+                            "host": ["{{endpoint}}"],
+                            "path": ["v2", "departure"],
+                            "query": [
+                                {
+                                    "key": "stop[]",
+                                    "value": "U1072",
+                                    "description": "Můstek"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "platform",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{endpoint}}/v2/departure?platform[]=U1072Z101P&platform[]=U1072Z102P",
+                            "host": ["{{endpoint}}"],
+                            "path": ["v2", "departure"],
+                            "query": [
+                                {
+                                    "key": "platform[]",
+                                    "value": "U1072Z101P"
+                                },
+                                {
+                                    "key": "platform[]",
+                                    "value": "U1072Z102P"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        },
+        {
+            "name": "stop",
+            "item": [
+                {
+                    "name": "all",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{endpoint}}/v1/stop/all",
+                            "host": ["{{endpoint}}"],
+                            "path": ["v1", "stop", "all"]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "{id}",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{endpoint}}/v1/stop/U1072",
+                            "host": ["{{endpoint}}"],
+                            "path": ["v1", "stop", "U1072"]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        },
+        {
+            "name": "platform",
+            "item": [
+                {
+                    "name": "all",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "var template = `",
+                                    "<style type=\"text/css\">",
+                                    "    .tftable {font-size:14px;color:#333333;width:100%;border-width: 1px;border-color: #87ceeb;border-collapse: collapse;}",
+                                    "    .tftable th {font-size:18px;background-color:#87ceeb;border-width: 1px;padding: 8px;border-style: solid;border-color: #87ceeb;text-align:left;}",
+                                    "    .tftable tr {background-color:#ffffff;}",
+                                    "    .tftable td {font-size:14px;border-width: 1px;padding: 8px;border-style: solid;border-color: #87ceeb;}",
+                                    "    .tftable tr:hover {background-color:#e0ffff;}",
+                                    "</style>",
+                                    "",
+                                    "<table class=\"tftable\" border=\"1\">",
+                                    "    <tr>",
+                                    "        <th>ID</th>",
+                                    "        <th>Latitude</th>",
+                                    "        <th>Longitude</th>",
+                                    "        <th>Name</th>",
+                                    "        <th>Routes</th>",
+                                    "    </tr>",
+                                    "    ",
+                                    "    {{#each response}}",
+                                    "        <tr>",
+                                    "            <td>{{id}}</td>",
+                                    "            <td>{{latitude}}</td>",
+                                    "            <td>{{longitude}}</td>",
+                                    "            <td>{{name}}</td>",
+                                    "            <td>",
+                                    "                <table>",
+                                    "                    <tr>",
+                                    "                        <th>ID</th>",
+                                    "                        <th>Name</th>",
+                                    "                    </tr>",
+                                    "                    {{#each routes}}",
+                                    "                        <tr>",
+                                    "                            <td>{{id}}</td>",
+                                    "                            <td>{{name}}</td>",
+                                    "                        </tr>",
+                                    "                    {{/each}}",
+                                    "                </table>",
+                                    "            </td>",
+                                    "        </tr>",
+                                    "    {{/each}}",
+                                    "</table>",
+                                    "`;",
+                                    "",
+                                    "function constructVisualizerPayload() {",
+                                    "    return { response: pm.response.json() }",
+                                    "}",
+                                    "",
+                                    "pm.visualizer.set(template, constructVisualizerPayload());"
+                                ],
+                                "type": "text/javascript",
+                                "packages": {}
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{endpoint}}/v1/platform/all",
+                            "host": ["{{endpoint}}"],
+                            "path": ["v1", "platform", "all"]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        }
+    ],
+    "variable": [
+        {
+            "key": "endpoint",
+            "value": "http://localhost:3001",
+            "type": "default"
+        }
+    ]
+}

--- a/apps/mobile/metro-now/metro-now Watch App/pages/closest-stop-list/ClosestStopListViewModel.swift
+++ b/apps/mobile/metro-now/metro-now Watch App/pages/closest-stop-list/ClosestStopListViewModel.swift
@@ -110,7 +110,7 @@ class ClosestStopListViewModel: NSObject, ObservableObject, CLLocationManagerDel
                 "stop": stopsIds,
                 "limit": 20,
                 "minutesBefore": 1,
-                "minutesAfter": String(5 * 60),
+                "minutesAfter": String(1 * 60),
             ]
         )
 

--- a/apps/mobile/metro-now/metro-now/pages/closest-stop/ClosestStopPageViewModel.swift
+++ b/apps/mobile/metro-now/metro-now/pages/closest-stop/ClosestStopPageViewModel.swift
@@ -155,7 +155,7 @@ class ClosestStopPageViewModel: NSObject, ObservableObject, CLLocationManagerDel
                 "platform": platformsIds,
                 "limit": 4,
                 "minutesBefore": 1,
-                "minutesAfter": String(3 * 60),
+                "minutesAfter": String(1 * 60),
             ]
         )
 

--- a/apps/mobile/metro-now/metro-now/pages/search/stop-detail/SearchPageDetailViewModel.swift
+++ b/apps/mobile/metro-now/metro-now/pages/search/stop-detail/SearchPageDetailViewModel.swift
@@ -74,7 +74,7 @@ class SearchPageDetailViewModel: NSObject, ObservableObject {
                 "platform": platformsIds,
                 "limit": 6,
                 "minutesBefore": 1,
-                "minutesAfter": String(12 * 60),
+                "minutesAfter": String(1 * 60),
             ]
         )
 

--- a/apps/mobile/metro-now/metro-now/pages/stop-detail/StopMetroDeparturesViewModel.swift
+++ b/apps/mobile/metro-now/metro-now/pages/stop-detail/StopMetroDeparturesViewModel.swift
@@ -74,7 +74,7 @@ class StopMetroDeparturesViewModel: NSObject, ObservableObject {
                 "platform": platformsIds,
                 "limit": 20,
                 "minutesBefore": 1,
-                "minutesAfter": String(8 * 60),
+                "minutesAfter": String(1 * 60),
             ]
         )
 

--- a/apps/mobile/metro-now/widgets/departures/DeparturesWidgetManager.swift
+++ b/apps/mobile/metro-now/widgets/departures/DeparturesWidgetManager.swift
@@ -66,7 +66,7 @@ class DeparturesWidgetManager: NSObject, ObservableObject, CLLocationManagerDele
         let stopQuery = stopIds.map { "stop[]=\($0)" }.joined(separator: "&")
         let platformQuery = platformIds.map { "platform[]=\($0)" }.joined(separator: "&")
 
-        let url = "\(API_URL)/v2/departure?\(stopQuery)&\(platformQuery)&limit=4&minutesBefore=1&minutesAfter=\(3 * 60)"
+        let url = "\(API_URL)/v2/departure?\(stopQuery)&\(platformQuery)&limit=4&minutesBefore=1&minutesAfter=\(1 * 60)"
 
         // Print the full API request URL for debugging
         print("API Request URL for Departures: \(url)")


### PR DESCRIPTION
# Changes
- [x] departures minutes after set to 1 hour everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an API collection showcasing metro service endpoints with built-in response visualizations for departures, stops, and platforms.
- **Bug Fixes**
	- Revised departure queries across mobile views. The app now displays upcoming departures within the next 60 minutes for a more focused and timely schedule.
- **Chores**
	- Updated the Dockerfile to install the `corepack` package globally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->