### PR TITLE
feat(web): add /app page with stop search, nearby stops, and departures

### DIFF
--- a/apps/backend/src/constants/api.ts
+++ b/apps/backend/src/constants/api.ts
@@ -1,4 +1,5 @@
-export const API_URL = "https://api.metronow.dev";
+// export const API_URL = "https://api.metronow.dev";
+export const API_URL = "http://localhost:3009";
 
 export const APPSTORE_URL =
     "https://apps.apple.com/cz/app/metro-now/id6504659402?platform=appleWatch";

--- a/apps/backend/src/constants/cache.ts
+++ b/apps/backend/src/constants/cache.ts
@@ -69,7 +69,8 @@ export const CACHE_KEYS = {
             buildCacheKey("route.getManyGraphQL", params),
         getManyGraphQLByPlatformId: (platformId: string) =>
             buildCacheKey("route.getManyGraphQLByPlatformId", platformId),
-        getOneGraphQL: (id: string) => buildCacheKey("route.getOneGraphQL", id),
+        getOneGraphQL: (params: unknown) =>
+            buildCacheKey("route.getOneGraphQL", params),
     },
     status: {
         getDbDataStatus: "status.getDbDataStatus",

--- a/apps/backend/src/modules/route/route.resolver.ts
+++ b/apps/backend/src/modules/route/route.resolver.ts
@@ -15,8 +15,11 @@ export class RouteResolver {
     }
 
     @Query("route")
-    getOne(@Args("id") id: string) {
-        return this.routeService.getOneGraphQL(this.toDatabaseRouteId(id));
+    getOne(@Args("id") id: string, @Args("feed") feed?: GtfsFeedId) {
+        return this.routeService.getOneGraphQL(
+            this.toDatabaseRouteId(id),
+            feed,
+        );
     }
 
     @Query("routes")

--- a/apps/backend/src/modules/route/route.service.ts
+++ b/apps/backend/src/modules/route/route.service.ts
@@ -44,6 +44,7 @@ type RoutePlatformRecord = Pick<
 >;
 
 type RouteStopRow = {
+    feedId: GtfsFeedId;
     directionId: string;
     platform: RoutePlatformRecord | null;
     routeId: string;
@@ -52,8 +53,11 @@ type RouteStopRow = {
 
 type RouteExactShapeRow = Pick<
     GtfsRouteShape,
-    "directionId" | "geoJson" | "routeId" | "shapeId" | "tripCount"
+    "directionId" | "feedId" | "geoJson" | "routeId" | "shapeId" | "tripCount"
 >;
+
+const getRouteCompositeKey = (routeId: string, feedId: GtfsFeedId): string =>
+    `${feedId}:${routeId}`;
 
 const processRoute = (
     route: RouteRow,
@@ -143,9 +147,13 @@ export class RouteService {
         @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     ) {}
 
-    private async loadRouteRows(
-        routeIds?: readonly string[],
-    ): Promise<RouteRow[]> {
+    private async loadRouteRows({
+        routeIds,
+        feedId,
+    }: {
+        routeIds?: readonly string[];
+        feedId?: GtfsFeedId;
+    }): Promise<RouteRow[]> {
         if (routeIds && routeIds.length === 0) {
             return [];
         }
@@ -167,14 +175,23 @@ export class RouteService {
             query = query.where("id", "in", [...routeIds]);
         }
 
-        return query.orderBy("id", "asc").execute();
+        if (feedId) {
+            query = query.where("feedId", "=", feedId);
+        }
+
+        return query.orderBy("id", "asc").orderBy("feedId", "asc").execute();
     }
 
     private async loadRouteStops(
         routeIds: readonly string[],
+        feedId?: GtfsFeedId,
     ): Promise<Map<string, RouteStopRow[]>> {
         const routeStopsByRouteId = new Map<string, RouteStopRow[]>(
-            routeIds.map((routeId) => [routeId, []]),
+            routeIds.map((routeId) =>
+                feedId
+                    ? [getRouteCompositeKey(routeId, feedId), []]
+                    : [routeId, []],
+            ),
         );
 
         if (routeIds.length === 0) {
@@ -185,6 +202,7 @@ export class RouteService {
             .selectFrom("GtfsRouteStop")
             .leftJoin("Platform", "Platform.id", "GtfsRouteStop.stopId")
             .select([
+                "GtfsRouteStop.feedId as feedId",
                 "GtfsRouteStop.routeId as routeId",
                 "GtfsRouteStop.directionId as directionId",
                 "GtfsRouteStop.stopSequence as stopSequence",
@@ -196,13 +214,22 @@ export class RouteService {
                 "Platform.code as platformCode",
             ])
             .where("GtfsRouteStop.routeId", "in", [...routeIds])
+            .$if(Boolean(feedId), (qb) =>
+                qb.where("GtfsRouteStop.feedId", "=", feedId as GtfsFeedId),
+            )
             .orderBy("GtfsRouteStop.routeId", "asc")
+            .orderBy("GtfsRouteStop.feedId", "asc")
             .orderBy("GtfsRouteStop.directionId", "asc")
             .orderBy("GtfsRouteStop.stopSequence", "asc")
             .execute();
 
         for (const row of rows) {
-            routeStopsByRouteId.get(row.routeId)?.push({
+            const key = feedId
+                ? getRouteCompositeKey(row.routeId, row.feedId)
+                : row.routeId;
+
+            routeStopsByRouteId.get(key)?.push({
+                feedId: row.feedId,
                 routeId: row.routeId,
                 directionId: row.directionId,
                 stopSequence: row.stopSequence,
@@ -224,9 +251,14 @@ export class RouteService {
 
     private async loadRouteExactShapes(
         routeIds: readonly string[],
+        feedId?: GtfsFeedId,
     ): Promise<Map<string, RouteExactShapeRow[]>> {
         const routeExactShapesByRouteId = new Map<string, RouteExactShapeRow[]>(
-            routeIds.map((routeId) => [routeId, []]),
+            routeIds.map((routeId) =>
+                feedId
+                    ? [getRouteCompositeKey(routeId, feedId), []]
+                    : [routeId, []],
+            ),
         );
 
         if (routeIds.length === 0) {
@@ -244,14 +276,19 @@ export class RouteService {
                 .selectFrom("GtfsRouteShape")
                 .select([
                     "routeId",
+                    "feedId",
                     "directionId",
                     "shapeId",
                     "tripCount",
                     "geoJson",
                 ])
                 .where("routeId", "in", [...routeIds])
+                .$if(Boolean(feedId), (qb) =>
+                    qb.where("feedId", "=", feedId as GtfsFeedId),
+                )
                 .where("isPrimary", "=", true)
                 .orderBy("routeId", "asc")
+                .orderBy("feedId", "asc")
                 .orderBy("directionId", "asc")
                 .orderBy("shapeId", "asc")
                 .execute();
@@ -267,7 +304,11 @@ export class RouteService {
         }
 
         for (const row of rows) {
-            routeExactShapesByRouteId.get(row.routeId)?.push(row);
+            const key = feedId
+                ? getRouteCompositeKey(row.routeId, row.feedId)
+                : row.routeId;
+
+            routeExactShapesByRouteId.get(key)?.push(row);
         }
 
         return routeExactShapesByRouteId;
@@ -295,19 +336,31 @@ export class RouteService {
 
     private async loadGraphQLRoutesByIds(
         routeIds: readonly string[],
+        feedId?: GtfsFeedId,
     ): Promise<GraphQLRouteRecord[]> {
         const [routes, routeStopsByRouteId, routeExactShapesByRouteId] =
             await Promise.all([
-                this.loadRouteRows(routeIds),
-                this.loadRouteStops(routeIds),
-                this.loadRouteExactShapes(routeIds),
+                this.loadRouteRows({
+                    routeIds,
+                    ...(feedId ? { feedId } : {}),
+                }),
+                this.loadRouteStops(routeIds, feedId),
+                this.loadRouteExactShapes(routeIds, feedId),
             ]);
 
         return routes.map((route) =>
             processRoute(
                 route,
-                routeStopsByRouteId.get(route.id) ?? [],
-                routeExactShapesByRouteId.get(route.id) ?? [],
+                routeStopsByRouteId.get(
+                    feedId
+                        ? getRouteCompositeKey(route.id, route.feedId)
+                        : route.id,
+                ) ?? [],
+                routeExactShapesByRouteId.get(
+                    feedId
+                        ? getRouteCompositeKey(route.id, route.feedId)
+                        : route.id,
+                ) ?? [],
             ),
         );
     }
@@ -325,21 +378,45 @@ export class RouteService {
 
         const routeLinks = await this.database.db
             .selectFrom("GtfsRouteStop")
-            .select(["routeId", "stopId as platformId"])
+            .select(["feedId", "routeId", "stopId as platformId"])
             .distinct()
             .where("stopId", "in", [...platformIds])
             .orderBy("routeId", "asc")
+            .orderBy("feedId", "asc")
             .execute();
-        const routeIds = uniqueSortedStrings(
-            routeLinks.map(({ routeId }) => routeId),
+        const routeKeys = uniqueSortedStrings(
+            routeLinks.map(({ feedId, routeId }) =>
+                getRouteCompositeKey(routeId, feedId),
+            ),
         );
-        const routes = await this.loadGraphQLRoutesByIds(routeIds);
+        const routes = await Promise.all(
+            routeKeys.map((routeKey) => {
+                const [feedId, routeId] = routeKey.split(":", 2) as [
+                    GtfsFeedId,
+                    string,
+                ];
+
+                return this.getOneGraphQL(routeId, feedId);
+            }),
+        );
         const routeById = new Map<string, GraphQLRouteRecord>(
-            routes.map((route) => [toLookupRouteId(route.id), route] as const),
+            routes.flatMap((route) =>
+                route
+                    ? [
+                          [
+                              getRouteCompositeKey(
+                                  toLookupRouteId(route.id),
+                                  route.feed,
+                              ),
+                              route,
+                          ] as const,
+                      ]
+                    : [],
+            ),
         );
 
-        for (const { platformId, routeId } of routeLinks) {
-            const route = routeById.get(routeId);
+        for (const { platformId, routeId, feedId } of routeLinks) {
+            const route = routeById.get(getRouteCompositeKey(routeId, feedId));
 
             if (route) {
                 routesByPlatformId.get(platformId)?.push(route);
@@ -353,7 +430,7 @@ export class RouteService {
         return this.cacheManager.wrap(
             CACHE_KEYS.route.getManyGraphQL({}),
             async () => {
-                const routeRows = await this.loadRouteRows();
+                const routeRows = await this.loadRouteRows({});
 
                 return this.loadGraphQLRoutesByIds(
                     routeRows.map((route) => route.id),
@@ -363,12 +440,18 @@ export class RouteService {
         );
     }
 
-    async getOneGraphQL(id: string): Promise<GraphQLRouteRecord | null> {
+    async getOneGraphQL(
+        id: string,
+        feedId?: GtfsFeedId,
+    ): Promise<GraphQLRouteRecord | null> {
         return this.cacheManager.wrap(
-            CACHE_KEYS.route.getOneGraphQL(id),
+            CACHE_KEYS.route.getOneGraphQL({ id, feedId }),
             async () => {
                 const lookupId = toLookupRouteId(id);
-                const [route] = await this.loadGraphQLRoutesByIds([lookupId]);
+                const [route] = await this.loadGraphQLRoutesByIds(
+                    [lookupId],
+                    feedId,
+                );
 
                 if (route) {
                     return route;

--- a/apps/backend/src/modules/route/schema.graphql
+++ b/apps/backend/src/modules/route/schema.graphql
@@ -56,6 +56,6 @@ type Route {
 }
 
 type Query {
-    route(id: ID!): Route
+    route(id: ID!, feed: Feed): Route
     routes: [Route!]!
 }

--- a/apps/backend/src/modules/stop/schema.graphql
+++ b/apps/backend/src/modules/stop/schema.graphql
@@ -7,6 +7,7 @@ type StopEntrance {
 
 type Stop {
     id: ID!
+    feed: Feed
     name: String!
     avgLatitude: Float!
     avgLongitude: Float!

--- a/apps/backend/src/modules/stop/stop.service.ts
+++ b/apps/backend/src/modules/stop/stop.service.ts
@@ -1,4 +1,5 @@
 import type {
+    GtfsFeedId,
     GtfsStationEntrance,
     Platform,
     Route,
@@ -19,7 +20,9 @@ import { loadCachedBatch } from "src/utils/cache-batch";
 type StopRecordBase = Pick<
     Stop,
     "avgLatitude" | "avgLongitude" | "id" | "name"
->;
+> & {
+    feed?: GtfsFeedId | null;
+};
 
 type PlatformRouteRecord = Pick<Route, "id" | "name"> & {
     color: string | null;
@@ -407,6 +410,7 @@ export class StopService {
             return [];
         }
 
+        const feedIdsByStopId = await this.loadStopFeedIdsByStopIds(ids);
         let query = this.database.db
             .selectFrom("Stop")
             .select(["id", "name", "avgLatitude", "avgLongitude"]);
@@ -423,7 +427,44 @@ export class StopService {
             query = query.limit(limit);
         }
 
-        return query.orderBy("id", "asc").execute();
+        const rows = await query.orderBy("id", "asc").execute();
+
+        return rows.map((row) => ({
+            ...row,
+            feed: feedIdsByStopId.get(row.id) ?? null,
+        }));
+    }
+
+    private async loadStopFeedIdsByStopIds(
+        stopIds?: readonly string[],
+    ): Promise<Map<string, GtfsFeedId>> {
+        const feedIdByStopId = new Map<string, GtfsFeedId>();
+
+        let query = this.database.db
+            .selectFrom("Platform")
+            .innerJoin("GtfsRouteStop", "GtfsRouteStop.stopId", "Platform.id")
+            .select([
+                "Platform.stopId as stopId",
+                "GtfsRouteStop.feedId as feedId",
+            ])
+            .distinct()
+            .where("Platform.stopId", "is not", null)
+            .orderBy("Platform.stopId", "asc")
+            .orderBy("GtfsRouteStop.feedId", "asc");
+
+        if (stopIds) {
+            query = query.where("Platform.stopId", "in", [...stopIds]);
+        }
+
+        const rows = await query.execute();
+
+        for (const row of rows) {
+            if (row.stopId && !feedIdByStopId.has(row.stopId)) {
+                feedIdByStopId.set(row.stopId, row.feedId);
+            }
+        }
+
+        return feedIdByStopId;
     }
 
     private async loadSearchableStopRows(): Promise<SearchableStopRow[]> {

--- a/apps/mobile/metro-now/metro-now Watch App/pages/stop/StopDeparturesView.swift
+++ b/apps/mobile/metro-now/metro-now Watch App/pages/stop/StopDeparturesView.swift
@@ -60,8 +60,6 @@ struct StopDeparturesView: View {
                     metroLine: platform.metroLine,
                     departures: platform.departures
                 )
-            } else {
-                EmptyView()
             }
         }
     }

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,3 +1,6 @@
+# Backend API URL (defaults to https://api.metronow.dev)
+# NEXT_PUBLIC_API_URL=http://localhost:3009
+
 # Mapbox api key https://docs.mapbox.com/help/getting-started/access-tokens/
 NEXT_PUBLIC_MAPBOX_TOKEN=
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@next/mdx": "^14.2.26",
+        "@radix-ui/react-dialog": "^1.1.15",
         "clsx": "^2.1.1",
         "framer-motion": "^11.18.2",
         "mapbox-gl": "^3.11.0",

--- a/apps/web/src/app/app/@modal/(.)route/[feedId]/[id]/page.tsx
+++ b/apps/web/src/app/app/@modal/(.)route/[feedId]/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { RouteModal } from "../../[id]/RouteModal";
+
+type Props = {
+    params: Promise<{ feedId: string; id: string }>;
+};
+
+export default async function InterceptedRoutePage({ params }: Props) {
+    const { feedId, id } = await params;
+
+    return (
+        <RouteModal
+            routeId={decodeURIComponent(id)}
+            feedId={decodeURIComponent(feedId)}
+        />
+    );
+}

--- a/apps/web/src/app/app/@modal/(.)route/[id]/RouteModal.tsx
+++ b/apps/web/src/app/app/@modal/(.)route/[id]/RouteModal.tsx
@@ -1,46 +1,44 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect } from "react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useCallback } from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import { RouteStopList } from "../../../route/[id]/RouteStopList";
 
-export const RouteModal = ({ routeId }: { routeId: string }) => {
+export const RouteModal = ({
+    routeId,
+    feedId,
+}: {
+    routeId: string;
+    feedId?: string;
+}) => {
     const router = useRouter();
 
     const close = useCallback(() => {
         router.back();
     }, [router]);
 
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === "Escape") close();
-        };
-        document.addEventListener("keydown", onKeyDown);
-        return () => document.removeEventListener("keydown", onKeyDown);
-    }, [close]);
-
     return (
-        <div
-            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center"
-            onClick={close}
+        <Dialog
+            open
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    close();
+                }
+            }}
         >
-            <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-
-            <div
-                className="relative bg-white dark:bg-neutral-900 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-md max-h-[80vh] overflow-y-auto p-6 shadow-xl"
-                onClick={(e) => e.stopPropagation()}
-            >
-                <button
-                    type="button"
-                    onClick={close}
-                    className="absolute top-4 right-4 p-1 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
-                >
-                    <XMarkIcon className="h-5 w-5 text-neutral-500" />
-                </button>
-
-                <RouteStopList routeId={routeId} />
-            </div>
-        </div>
+            <DialogContent className="sm:max-w-md">
+                <DialogTitle className="sr-only">Route stops</DialogTitle>
+                <DialogDescription className="sr-only">
+                    Shows the full stop list for the selected line.
+                </DialogDescription>
+                <RouteStopList routeId={routeId} feedId={feedId} />
+            </DialogContent>
+        </Dialog>
     );
 };

--- a/apps/web/src/app/app/@modal/(.)route/[id]/RouteModal.tsx
+++ b/apps/web/src/app/app/@modal/(.)route/[id]/RouteModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { RouteStopList } from "../../../route/[id]/RouteStopList";
+
+export const RouteModal = ({ routeId }: { routeId: string }) => {
+    const router = useRouter();
+
+    const close = useCallback(() => {
+        router.back();
+    }, [router]);
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") close();
+        };
+        document.addEventListener("keydown", onKeyDown);
+        return () => document.removeEventListener("keydown", onKeyDown);
+    }, [close]);
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center"
+            onClick={close}
+        >
+            <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+
+            <div
+                className="relative bg-white dark:bg-neutral-900 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-md max-h-[80vh] overflow-y-auto p-6 shadow-xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <button
+                    type="button"
+                    onClick={close}
+                    className="absolute top-4 right-4 p-1 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+                >
+                    <XMarkIcon className="h-5 w-5 text-neutral-500" />
+                </button>
+
+                <RouteStopList routeId={routeId} />
+            </div>
+        </div>
+    );
+};

--- a/apps/web/src/app/app/@modal/(.)route/[id]/page.tsx
+++ b/apps/web/src/app/app/@modal/(.)route/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { RouteModal } from "./RouteModal";
+
+type Props = {
+    params: Promise<{ id: string }>;
+};
+
+export default async function InterceptedRoutePage({ params }: Props) {
+    const { id } = await params;
+    const routeId = decodeURIComponent(id);
+
+    return <RouteModal routeId={routeId} />;
+}

--- a/apps/web/src/app/app/@modal/(.)stop/[feedId]/[id]/page.tsx
+++ b/apps/web/src/app/app/@modal/(.)stop/[feedId]/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import { graphqlFetch } from "@/utils/graphql-client";
+import { StopModal } from "../../[id]/StopModal";
+
+type Stop = {
+    id: string;
+    feed: string | null;
+    name: string;
+};
+
+const getStop = async (id: string): Promise<Stop | null> => {
+    try {
+        const data = await graphqlFetch<{ stop: Stop | null }>(
+            `query GetStopModal($id: ID!) {
+                stop(id: $id) {
+                    id
+                    feed
+                    name
+                }
+            }`,
+            { id },
+            { next: { revalidate: 3600 } },
+        );
+
+        return data.stop;
+    } catch {
+        return null;
+    }
+};
+
+type Props = {
+    params: Promise<{ feedId: string; id: string }>;
+};
+
+export default async function InterceptedStopPage({ params }: Props) {
+    const { feedId, id } = await params;
+    const stop = await getStop(decodeURIComponent(id));
+    const decodedFeedId = decodeURIComponent(feedId);
+
+    if (!stop || stop.feed !== decodedFeedId) {
+        notFound();
+    }
+
+    return <StopModal stopId={stop.id} stopName={stop.name} />;
+}

--- a/apps/web/src/app/app/@modal/(.)stop/[id]/StopModal.tsx
+++ b/apps/web/src/app/app/@modal/(.)stop/[id]/StopModal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { DepartureBoard } from "../../../stop/[id]/DepartureBoard";
+
+export const StopModal = ({
+    stopId,
+    stopName,
+}: {
+    stopId: string;
+    stopName: string;
+}) => {
+    const router = useRouter();
+
+    const close = useCallback(() => {
+        router.back();
+    }, [router]);
+
+    return (
+        <Dialog
+            open
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    close();
+                }
+            }}
+        >
+            <DialogContent className="sm:max-w-md">
+                <DialogTitle className="mb-4 pr-10 text-2xl">{stopName}</DialogTitle>
+                <DialogDescription className="sr-only">
+                    Shows live departures for the selected stop.
+                </DialogDescription>
+                <DepartureBoard stopId={stopId} />
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/apps/web/src/app/app/@modal/(.)stop/[id]/page.tsx
+++ b/apps/web/src/app/app/@modal/(.)stop/[id]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from "next/navigation";
+import { graphqlFetch } from "@/utils/graphql-client";
+import { StopModal } from "./StopModal";
+
+type Stop = {
+    id: string;
+    feed: string | null;
+    name: string;
+};
+
+const getStop = async (id: string): Promise<Stop | null> => {
+    try {
+        const data = await graphqlFetch<{ stop: Stop | null }>(
+            `query GetStopModal($id: ID!) {
+                stop(id: $id) {
+                    id
+                    feed
+                    name
+                }
+            }`,
+            { id },
+            { next: { revalidate: 3600 } },
+        );
+
+        return data.stop;
+    } catch {
+        return null;
+    }
+};
+
+type Props = {
+    params: Promise<{ id: string }>;
+};
+
+export default async function InterceptedStopPage({ params }: Props) {
+    const { id } = await params;
+    const stop = await getStop(decodeURIComponent(id));
+
+    if (!stop) {
+        notFound();
+    }
+
+    return <StopModal stopId={stop.id} stopName={stop.name} />;
+}

--- a/apps/web/src/app/app/@modal/default.tsx
+++ b/apps/web/src/app/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+    return null;
+}

--- a/apps/web/src/app/app/layout.tsx
+++ b/apps/web/src/app/app/layout.tsx
@@ -8,8 +8,15 @@ export const metadata: Metadata = {
 
 export default function AppLayout({
     children,
+    modal,
 }: Readonly<{
     children: React.ReactNode;
+    modal: React.ReactNode;
 }>) {
-    return children;
+    return (
+        <>
+            {children}
+            {modal}
+        </>
+    );
 }

--- a/apps/web/src/app/app/layout.tsx
+++ b/apps/web/src/app/app/layout.tsx
@@ -1,0 +1,15 @@
+import { getTitle } from "@/utils/metadata.utils";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: getTitle("App"),
+    description: "Search stops and view real-time departures",
+};
+
+export default function AppLayout({
+    children,
+}: Readonly<{
+    children: React.ReactNode;
+}>) {
+    return children;
+}

--- a/apps/web/src/app/app/page.tsx
+++ b/apps/web/src/app/app/page.tsx
@@ -2,12 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { GRAPHQL_URL } from "@/constants/api";
+import { getStopPath } from "@/utils/app-paths";
+import { graphqlFetch } from "@/utils/graphql-client";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { MapPinIcon } from "@heroicons/react/24/solid";
 
 type StopResult = {
     id: string;
+    feed: string | null;
     name: string;
     avgLatitude: number;
     avgLongitude: number;
@@ -46,18 +48,9 @@ const formatDistance = (meters: number): string => {
     return `${(meters / 1000).toFixed(1)} km`;
 };
 
-const graphqlFetch = async <T,>(query: string, variables?: Record<string, unknown>): Promise<T> => {
-    const res = await fetch(GRAPHQL_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query, variables }),
-    });
-    const json = await res.json();
-    return json.data;
-};
-
 const STOP_FIELDS = `
     id
+    feed
     name
     avgLatitude
     avgLongitude
@@ -132,7 +125,7 @@ const StopCard = ({ stop, distance }: { stop: StopResult; distance?: number }) =
 
     return (
         <Link
-            href={`/app/stop/${stop.id}`}
+            href={stop.feed ? getStopPath(stop.feed, stop.id) : "#"}
             className="block p-4 rounded-xl border border-neutral-200 dark:border-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-colors bg-white dark:bg-neutral-900"
         >
             <div className="flex items-start justify-between gap-2">

--- a/apps/web/src/app/app/page.tsx
+++ b/apps/web/src/app/app/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { GRAPHQL_URL } from "@/constants/api";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { MapPinIcon } from "@heroicons/react/24/solid";
+
+type StopResult = {
+    id: string;
+    name: string;
+    avgLatitude: number;
+    avgLongitude: number;
+    platforms: {
+        id: string;
+        routes: {
+            name: string | null;
+            color: string | null;
+            vehicleType: string;
+        }[];
+    }[];
+};
+
+type NearbyStop = StopResult & { distance: number };
+
+const haversineDistance = (
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+): number => {
+    const R = 6371e3;
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+const formatDistance = (meters: number): string => {
+    if (meters < 1000) {
+        return `${Math.round(meters)} m`;
+    }
+    return `${(meters / 1000).toFixed(1)} km`;
+};
+
+const graphqlFetch = async <T,>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+    const res = await fetch(GRAPHQL_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query, variables }),
+    });
+    const json = await res.json();
+    return json.data;
+};
+
+const STOP_FIELDS = `
+    id
+    name
+    avgLatitude
+    avgLongitude
+    platforms {
+        id
+        routes {
+            name
+            color
+            vehicleType
+        }
+    }
+`;
+
+const uniqueRoutes = (stop: StopResult) => {
+    const seen = new Set<string>();
+    const routes: { name: string; color: string | null; vehicleType: string }[] = [];
+    for (const platform of stop.platforms) {
+        for (const route of platform.routes) {
+            if (!route.name || seen.has(route.name)) continue;
+            seen.add(route.name);
+            routes.push({ ...route, name: route.name });
+        }
+    }
+    return routes;
+};
+
+const vehicleTypeOrder: Record<string, number> = {
+    SUBWAY: 0,
+    TRAIN: 1,
+    TRAM: 2,
+    BUS: 3,
+    TROLLEYBUS: 4,
+    FERRY: 5,
+    FUNICULAR: 6,
+};
+
+const sortRoutes = (routes: { name: string; color: string | null; vehicleType: string }[]) =>
+    [...routes].sort((a, b) => {
+        const typeA = vehicleTypeOrder[a.vehicleType] ?? 99;
+        const typeB = vehicleTypeOrder[b.vehicleType] ?? 99;
+        if (typeA !== typeB) return typeA - typeB;
+        return a.name.localeCompare(b.name, undefined, { numeric: true });
+    });
+
+const RouteBadge = ({ route }: { route: { name: string; color: string | null; vehicleType: string } }) => {
+    const bgColor = route.color ? `#${route.color}` : undefined;
+    const isLight = bgColor ? isLightColor(bgColor) : false;
+
+    return (
+        <span
+            className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-xs font-semibold min-w-[28px]"
+            style={{
+                backgroundColor: bgColor ?? "#6b7280",
+                color: isLight ? "#000" : "#fff",
+            }}
+        >
+            {route.name}
+        </span>
+    );
+};
+
+const isLightColor = (hex: string): boolean => {
+    const c = hex.replace("#", "");
+    const r = Number.parseInt(c.substring(0, 2), 16);
+    const g = Number.parseInt(c.substring(2, 4), 16);
+    const b = Number.parseInt(c.substring(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 > 150;
+};
+
+const StopCard = ({ stop, distance }: { stop: StopResult; distance?: number }) => {
+    const routes = sortRoutes(uniqueRoutes(stop));
+
+    return (
+        <Link
+            href={`/app/stop/${stop.id}`}
+            className="block p-4 rounded-xl border border-neutral-200 dark:border-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-colors bg-white dark:bg-neutral-900"
+        >
+            <div className="flex items-start justify-between gap-2">
+                <h3 className="font-medium text-neutral-900 dark:text-neutral-100">
+                    {stop.name}
+                </h3>
+                {typeof distance === "number" && (
+                    <span className="text-xs text-neutral-500 dark:text-neutral-400 whitespace-nowrap flex items-center gap-1">
+                        <MapPinIcon className="h-3 w-3" />
+                        {formatDistance(distance)}
+                    </span>
+                )}
+            </div>
+            {routes.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                    {routes.map((route) => (
+                        <RouteBadge key={route.name} route={route} />
+                    ))}
+                </div>
+            )}
+        </Link>
+    );
+};
+
+type LocationState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "denied" }
+    | { status: "error"; message: string }
+    | { status: "loaded"; latitude: number; longitude: number };
+
+export default function AppPage() {
+    const [searchQuery, setSearchQuery] = useState("");
+    const [searchResults, setSearchResults] = useState<StopResult[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [nearbyStops, setNearbyStops] = useState<NearbyStop[]>([]);
+    const [locationState, setLocationState] = useState<LocationState>({ status: "idle" });
+    const [isLoadingNearby, setIsLoadingNearby] = useState(false);
+    const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const searchStops = useCallback(async (query: string) => {
+        if (query.trim().length === 0) {
+            setSearchResults([]);
+            setIsSearching(false);
+            return;
+        }
+
+        setIsSearching(true);
+        try {
+            const data = await graphqlFetch<{ searchStops: StopResult[] }>(
+                `query SearchStops($query: String!) {
+                    searchStops(query: $query, limit: 20) {
+                        ${STOP_FIELDS}
+                    }
+                }`,
+                { query: query.trim() },
+            );
+            setSearchResults(data.searchStops);
+        } catch {
+            setSearchResults([]);
+        } finally {
+            setIsSearching(false);
+        }
+    }, []);
+
+    const handleSearchChange = (value: string) => {
+        setSearchQuery(value);
+        if (searchTimeoutRef.current) {
+            clearTimeout(searchTimeoutRef.current);
+        }
+        searchTimeoutRef.current = setTimeout(() => {
+            searchStops(value);
+        }, 300);
+    };
+
+    const loadNearbyStops = useCallback(async (lat: number, lon: number) => {
+        setIsLoadingNearby(true);
+        try {
+            const data = await graphqlFetch<{ stops: StopResult[] }>(
+                `query AllStops {
+                    stops(limit: 500) {
+                        ${STOP_FIELDS}
+                    }
+                }`,
+            );
+            const withDistance = data.stops
+                .map((stop) => ({
+                    ...stop,
+                    distance: haversineDistance(lat, lon, stop.avgLatitude, stop.avgLongitude),
+                }))
+                .sort((a, b) => a.distance - b.distance)
+                .slice(0, 15);
+            setNearbyStops(withDistance);
+        } catch {
+            setNearbyStops([]);
+        } finally {
+            setIsLoadingNearby(false);
+        }
+    }, []);
+
+    const requestLocation = useCallback(() => {
+        if (!navigator.geolocation) {
+            setLocationState({ status: "error", message: "Geolocation is not supported" });
+            return;
+        }
+
+        setLocationState({ status: "loading" });
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const { latitude, longitude } = position.coords;
+                setLocationState({ status: "loaded", latitude, longitude });
+                loadNearbyStops(latitude, longitude);
+            },
+            (error) => {
+                if (error.code === error.PERMISSION_DENIED) {
+                    setLocationState({ status: "denied" });
+                } else {
+                    setLocationState({ status: "error", message: "Could not get your location" });
+                }
+            },
+            { enableHighAccuracy: false, timeout: 10000 },
+        );
+    }, [loadNearbyStops]);
+
+    useEffect(() => {
+        requestLocation();
+    }, [requestLocation]);
+
+    const showSearchResults = searchQuery.trim().length > 0;
+
+    return (
+        <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+            <h1 className="text-2xl font-bold mb-6">Departures</h1>
+
+            <div className="relative mb-8">
+                <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400" />
+                <input
+                    type="text"
+                    placeholder="Search stops..."
+                    value={searchQuery}
+                    onChange={(e) => handleSearchChange(e.target.value)}
+                    className="w-full pl-10 pr-4 py-3 rounded-xl border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder-neutral-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-brandOrange focus:border-transparent"
+                />
+            </div>
+
+            {showSearchResults ? (
+                <section>
+                    <h2 className="text-sm font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-3">
+                        Search results
+                    </h2>
+                    {isSearching ? (
+                        <p className="text-neutral-500 dark:text-neutral-400 text-sm py-4 text-center">
+                            Searching...
+                        </p>
+                    ) : searchResults.length === 0 ? (
+                        <p className="text-neutral-500 dark:text-neutral-400 text-sm py-4 text-center">
+                            No stops found
+                        </p>
+                    ) : (
+                        <div className="flex flex-col gap-2">
+                            {searchResults.map((stop) => (
+                                <StopCard key={stop.id} stop={stop} />
+                            ))}
+                        </div>
+                    )}
+                </section>
+            ) : (
+                <section>
+                    <h2 className="text-sm font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-3">
+                        Nearby stops
+                    </h2>
+
+                    {locationState.status === "idle" || locationState.status === "loading" || isLoadingNearby ? (
+                        <p className="text-neutral-500 dark:text-neutral-400 text-sm py-4 text-center">
+                            Finding nearby stops...
+                        </p>
+                    ) : locationState.status === "denied" ? (
+                        <div className="text-center py-8">
+                            <MapPinIcon className="h-8 w-8 text-neutral-400 mx-auto mb-2" />
+                            <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-3">
+                                Location access was denied
+                            </p>
+                            <p className="text-neutral-400 dark:text-neutral-500 text-xs">
+                                Use the search bar above to find stops
+                            </p>
+                        </div>
+                    ) : locationState.status === "error" ? (
+                        <div className="text-center py-8">
+                            <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-2">
+                                {locationState.message}
+                            </p>
+                            <button
+                                type="button"
+                                onClick={requestLocation}
+                                className="text-brandOrange text-sm font-medium hover:underline"
+                            >
+                                Try again
+                            </button>
+                        </div>
+                    ) : nearbyStops.length === 0 ? (
+                        <p className="text-neutral-500 dark:text-neutral-400 text-sm py-4 text-center">
+                            No stops found nearby
+                        </p>
+                    ) : (
+                        <div className="flex flex-col gap-2">
+                            {nearbyStops.map((stop) => (
+                                <StopCard key={stop.id} stop={stop} distance={stop.distance} />
+                            ))}
+                        </div>
+                    )}
+                </section>
+            )}
+        </main>
+    );
+}

--- a/apps/web/src/app/app/page.tsx
+++ b/apps/web/src/app/app/page.tsx
@@ -234,8 +234,17 @@ export default function AppPage() {
     }, []);
 
     const requestLocation = useCallback(() => {
-        if (!navigator.geolocation) {
+        if (typeof window === "undefined" || !navigator.geolocation) {
             setLocationState({ status: "error", message: "Geolocation is not supported" });
+            return;
+        }
+
+        const isSecureContext = window.isSecureContext;
+        if (!isSecureContext) {
+            setLocationState({
+                status: "error",
+                message: "Location requires HTTPS. Use search instead.",
+            });
             return;
         }
 
@@ -249,11 +258,13 @@ export default function AppPage() {
             (error) => {
                 if (error.code === error.PERMISSION_DENIED) {
                     setLocationState({ status: "denied" });
+                } else if (error.code === error.TIMEOUT) {
+                    setLocationState({ status: "error", message: "Location request timed out" });
                 } else {
                     setLocationState({ status: "error", message: "Could not get your location" });
                 }
             },
-            { enableHighAccuracy: false, timeout: 10000 },
+            { enableHighAccuracy: false, timeout: 15000, maximumAge: 60000 },
         );
     }, [loadNearbyStops]);
 

--- a/apps/web/src/app/app/route/[feedId]/[id]/page.tsx
+++ b/apps/web/src/app/app/route/[feedId]/[id]/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { RouteStopList } from "../../[id]/RouteStopList";
+
+type Props = {
+    params: Promise<{ feedId: string; id: string }>;
+};
+
+export default async function RouteDetailPage({ params }: Props) {
+    const { feedId, id } = await params;
+
+    return (
+        <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+            <Link
+                href="/app"
+                className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
+            >
+                <ArrowLeftIcon className="h-4 w-4" />
+                Back
+            </Link>
+
+            <RouteStopList
+                routeId={decodeURIComponent(id)}
+                feedId={decodeURIComponent(feedId)}
+            />
+        </main>
+    );
+}

--- a/apps/web/src/app/app/route/[id]/RouteStopList.tsx
+++ b/apps/web/src/app/app/route/[id]/RouteStopList.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { GRAPHQL_URL } from "@/constants/api";
+import { getStopPath } from "@/utils/app-paths";
+import { graphqlFetch } from "@/utils/graphql-client";
 
 type Platform = {
     id: string;
@@ -17,6 +18,7 @@ type Direction = {
 
 type Route = {
     id: string;
+    feed: string;
     name: string | null;
     color: string | null;
     vehicleType: string;
@@ -43,43 +45,46 @@ const dedupeStops = (platforms: Platform[]): { id: string | null; name: string }
     return stops;
 };
 
-export const RouteStopList = ({ routeId }: { routeId: string }) => {
+export const RouteStopList = ({
+    routeId,
+    feedId,
+}: {
+    routeId: string;
+    feedId?: string;
+}) => {
     const [route, setRoute] = useState<Route | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
     const loadRoute = useCallback(async () => {
         try {
-            const res = await fetch(GRAPHQL_URL, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    query: `query GetRoute($id: ID!) {
-                        route(id: $id) {
+            const data = await graphqlFetch<{ route: Route | null }>(
+                `query GetRoute($id: ID!, $feed: Feed) {
+                    route(id: $id, feed: $feed) {
+                        id
+                        feed
+                        name
+                        color
+                        vehicleType
+                        directions {
                             id
-                            name
-                            color
-                            vehicleType
-                            directions {
+                            platforms {
                                 id
-                                platforms {
-                                    id
-                                    name
-                                    stop { id name }
-                                }
+                                name
+                                stop { id name }
                             }
                         }
-                    }`,
-                    variables: { id: routeId },
-                }),
-            });
-            const json = await res.json();
-            setRoute(json.data?.route ?? null);
+                    }
+                }`,
+                { id: routeId, feed: feedId },
+            );
+
+            setRoute(data.route ?? null);
         } catch {
             setRoute(null);
         } finally {
             setIsLoading(false);
         }
-    }, [routeId]);
+    }, [feedId, routeId]);
 
     useEffect(() => {
         loadRoute();
@@ -158,7 +163,7 @@ export const RouteStopList = ({ routeId }: { routeId: string }) => {
                                         </div>
                                         {stop.id ? (
                                             <Link
-                                                href={`/app/stop/${encodeURIComponent(stop.id)}`}
+                                                href={getStopPath(route.feed, stop.id)}
                                                 className="py-2 text-sm text-neutral-900 dark:text-neutral-100 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
                                             >
                                                 {stop.name}

--- a/apps/web/src/app/app/route/[id]/RouteStopList.tsx
+++ b/apps/web/src/app/app/route/[id]/RouteStopList.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { GRAPHQL_URL } from "@/constants/api";
+
+type Platform = {
+    id: string;
+    name: string;
+    stop: { id: string; name: string } | null;
+};
+
+type Direction = {
+    id: string;
+    platforms: Platform[];
+};
+
+type Route = {
+    id: string;
+    name: string | null;
+    color: string | null;
+    vehicleType: string;
+    directions: Direction[];
+};
+
+const isLightColor = (hex: string): boolean => {
+    const c = hex.replace("#", "");
+    const r = Number.parseInt(c.substring(0, 2), 16);
+    const g = Number.parseInt(c.substring(2, 4), 16);
+    const b = Number.parseInt(c.substring(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 > 150;
+};
+
+const dedupeStops = (platforms: Platform[]): { id: string | null; name: string }[] => {
+    const seen = new Set<string>();
+    const stops: { id: string | null; name: string }[] = [];
+    for (const platform of platforms) {
+        const name = platform.stop?.name ?? platform.name;
+        if (seen.has(name)) continue;
+        seen.add(name);
+        stops.push({ id: platform.stop?.id ?? null, name });
+    }
+    return stops;
+};
+
+export const RouteStopList = ({ routeId }: { routeId: string }) => {
+    const [route, setRoute] = useState<Route | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const loadRoute = useCallback(async () => {
+        try {
+            const res = await fetch(GRAPHQL_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    query: `query GetRoute($id: ID!) {
+                        route(id: $id) {
+                            id
+                            name
+                            color
+                            vehicleType
+                            directions {
+                                id
+                                platforms {
+                                    id
+                                    name
+                                    stop { id name }
+                                }
+                            }
+                        }
+                    }`,
+                    variables: { id: routeId },
+                }),
+            });
+            const json = await res.json();
+            setRoute(json.data?.route ?? null);
+        } catch {
+            setRoute(null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [routeId]);
+
+    useEffect(() => {
+        loadRoute();
+    }, [loadRoute]);
+
+    if (isLoading) {
+        return (
+            <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
+                Loading route...
+            </p>
+        );
+    }
+
+    if (!route) {
+        return (
+            <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
+                Route not found
+            </p>
+        );
+    }
+
+    const routeColor = route.color ? `#${route.color}` : "#6b7280";
+    const routeIsLight = isLightColor(routeColor);
+
+    return (
+        <div>
+            <div className="flex items-center gap-3 mb-6">
+                <span
+                    className="inline-flex items-center justify-center px-3 py-1.5 rounded font-bold text-lg min-w-[48px] text-center"
+                    style={{
+                        backgroundColor: routeColor,
+                        color: routeIsLight ? "#000" : "#fff",
+                    }}
+                >
+                    {route.name ?? "?"}
+                </span>
+                <span className="text-sm text-neutral-500 dark:text-neutral-400 capitalize">
+                    {route.vehicleType.toLowerCase()}
+                </span>
+            </div>
+
+            {route.directions.map((direction, dirIndex) => {
+                const stops = dedupeStops(direction.platforms);
+                if (stops.length === 0) return null;
+
+                return (
+                    <div key={direction.id} className={dirIndex > 0 ? "mt-6" : ""}>
+                        {route.directions.length > 1 && (
+                            <h3 className="text-xs font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2">
+                                {stops[0].name} → {stops[stops.length - 1].name}
+                            </h3>
+                        )}
+                        <ol className="relative ml-3">
+                            {stops.map((stop, i) => {
+                                const isFirst = i === 0;
+                                const isLast = i === stops.length - 1;
+
+                                return (
+                                    <li key={stop.id ?? stop.name} className="relative flex items-stretch">
+                                        <div className="flex flex-col items-center mr-3">
+                                            <div
+                                                className="w-0.5 flex-1"
+                                                style={{ backgroundColor: isFirst ? "transparent" : routeColor }}
+                                            />
+                                            <div
+                                                className="w-3 h-3 rounded-full border-2 flex-shrink-0"
+                                                style={{
+                                                    borderColor: routeColor,
+                                                    backgroundColor: isFirst || isLast ? routeColor : "transparent",
+                                                }}
+                                            />
+                                            <div
+                                                className="w-0.5 flex-1"
+                                                style={{ backgroundColor: isLast ? "transparent" : routeColor }}
+                                            />
+                                        </div>
+                                        {stop.id ? (
+                                            <Link
+                                                href={`/app/stop/${encodeURIComponent(stop.id)}`}
+                                                className="py-2 text-sm text-neutral-900 dark:text-neutral-100 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
+                                            >
+                                                {stop.name}
+                                            </Link>
+                                        ) : (
+                                            <span className="py-2 text-sm text-neutral-900 dark:text-neutral-100">
+                                                {stop.name}
+                                            </span>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/apps/web/src/app/app/route/[id]/default.tsx
+++ b/apps/web/src/app/app/route/[id]/default.tsx
@@ -1,0 +1,1 @@
+export { default } from "./page";

--- a/apps/web/src/app/app/route/[id]/page.tsx
+++ b/apps/web/src/app/app/route/[id]/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { RouteStopList } from "./RouteStopList";
+
+type Props = {
+    params: Promise<{ id: string }>;
+};
+
+export default async function RouteDetailPage({ params }: Props) {
+    const { id } = await params;
+    const routeId = decodeURIComponent(id);
+
+    return (
+        <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+            <Link
+                href="/app"
+                className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
+            >
+                <ArrowLeftIcon className="h-4 w-4" />
+                Back
+            </Link>
+
+            <RouteStopList routeId={routeId} />
+        </main>
+    );
+}

--- a/apps/web/src/app/app/stop/[feedId]/[id]/page.tsx
+++ b/apps/web/src/app/app/stop/[feedId]/[id]/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { graphqlFetch } from "@/utils/graphql-client";
+import { getTitle } from "@/utils/metadata.utils";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { DepartureBoard } from "../../[id]/DepartureBoard";
+import type { Metadata } from "next";
+
+type Stop = {
+    id: string;
+    feed: string | null;
+    name: string;
+    avgLatitude: number;
+    avgLongitude: number;
+};
+
+const fetchStop = async (id: string): Promise<Stop | null> => {
+    try {
+        const data = await graphqlFetch<{ stop: Stop | null }>(
+            `query GetStop($id: ID!) {
+                stop(id: $id) {
+                    id
+                    feed
+                    name
+                    avgLatitude
+                    avgLongitude
+                }
+            }`,
+            { id },
+            { next: { revalidate: 3600 } },
+        );
+
+        return data.stop;
+    } catch {
+        return null;
+    }
+};
+
+type Props = {
+    params: Promise<{ feedId: string; id: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { feedId, id } = await params;
+    const stop = await fetchStop(decodeURIComponent(id));
+    const decodedFeedId = decodeURIComponent(feedId);
+
+    return {
+        title:
+            stop?.feed === decodedFeedId ? getTitle(stop.name) : getTitle("Stop"),
+        description:
+            stop?.feed === decodedFeedId
+                ? `Real-time departures from ${stop.name}`
+                : "Stop not found",
+    };
+}
+
+export default async function StopDetailPage({ params }: Props) {
+    const { feedId, id } = await params;
+    const stop = await fetchStop(decodeURIComponent(id));
+    const decodedFeedId = decodeURIComponent(feedId);
+
+    if (!stop || stop.feed !== decodedFeedId) {
+        notFound();
+    }
+
+    return (
+        <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+            <Link
+                href="/app"
+                className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
+            >
+                <ArrowLeftIcon className="h-4 w-4" />
+                Back
+            </Link>
+
+            <h1 className="text-2xl font-bold mb-4">{stop.name}</h1>
+
+            <DepartureBoard stopId={stop.id} />
+        </main>
+    );
+}

--- a/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
+++ b/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { GRAPHQL_URL } from "@/constants/api";
+import { ClockIcon } from "@heroicons/react/24/outline";
+
+type Departure = {
+    id: string | null;
+    headsign: string | null;
+    delay: number | null;
+    isRealtime: boolean;
+    platformCode: string | null;
+    departureTime: {
+        predicted: string;
+        scheduled: string;
+    };
+    route: {
+        name: string | null;
+        color: string | null;
+        vehicleType: string;
+    } | null;
+};
+
+type DepartureGroup = {
+    key: string;
+    departures: Departure[];
+};
+
+const isLightColor = (hex: string): boolean => {
+    const c = hex.replace("#", "");
+    const r = Number.parseInt(c.substring(0, 2), 16);
+    const g = Number.parseInt(c.substring(2, 4), 16);
+    const b = Number.parseInt(c.substring(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 > 150;
+};
+
+const formatDepartureTime = (isoString: string): string => {
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const diffMin = Math.round(diffMs / 60000);
+
+    if (diffMin <= 0) return "now";
+    if (diffMin < 60) return `${diffMin} min`;
+
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+};
+
+const formatDelay = (delaySeconds: number): string => {
+    const minutes = Math.round(delaySeconds / 60);
+    if (minutes === 0) return "";
+    return minutes > 0 ? `+${minutes}` : `${minutes}`;
+};
+
+const groupDepartures = (departures: Departure[]): DepartureGroup[] => {
+    const groups: DepartureGroup[] = [];
+    const groupMap = new Map<string, DepartureGroup>();
+
+    for (const departure of departures) {
+        const key = `${departure.route?.name ?? "?"}::${departure.headsign ?? ""}`;
+        const existing = groupMap.get(key);
+        if (existing) {
+            existing.departures.push(departure);
+        } else {
+            const group = { key, departures: [departure] };
+            groupMap.set(key, group);
+            groups.push(group);
+        }
+    }
+
+    return groups;
+};
+
+const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
+    const first = group.departures[0];
+    const rest = group.departures.slice(1);
+    const routeColor = first.route?.color ? `#${first.route.color}` : "#6b7280";
+    const routeIsLight = isLightColor(routeColor);
+    const timeStr = formatDepartureTime(first.departureTime.predicted);
+    const delayStr = first.delay ? formatDelay(first.delay) : "";
+
+    return (
+        <div className="py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0">
+            <div className="flex items-center gap-3">
+                <span
+                    className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center"
+                    style={{
+                        backgroundColor: routeColor,
+                        color: routeIsLight ? "#000" : "#fff",
+                    }}
+                >
+                    {first.route?.name ?? "?"}
+                </span>
+
+                <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
+                        {first.headsign ?? "Unknown destination"}
+                    </p>
+                    {first.platformCode && (
+                        <p className="text-xs text-neutral-400 dark:text-neutral-500">
+                            Platform {first.platformCode}
+                        </p>
+                    )}
+                </div>
+
+                <div className="text-right flex items-center gap-1.5">
+                    <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100 tabular-nums">
+                        {timeStr}
+                    </span>
+                    {delayStr && (
+                        <span className="text-xs text-red-500 font-medium tabular-nums">
+                            {delayStr}
+                        </span>
+                    )}
+                    {first.isRealtime && (
+                        <span className="h-2 w-2 rounded-full bg-green-500 flex-shrink-0" title="Real-time" />
+                    )}
+                </div>
+            </div>
+
+            {rest.length > 0 && (
+                <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1 ml-[56px]">
+                    also in{" "}
+                    {rest.map((dep, i) => (
+                        <span key={dep.id ?? `next-${i}`}>
+                            {i > 0 && ", "}
+                            {formatDepartureTime(dep.departureTime.predicted)}
+                        </span>
+                    ))}
+                </p>
+            )}
+        </div>
+    );
+};
+
+const REFRESH_INTERVAL_MS = 15_000;
+
+export const DepartureBoard = ({ stopId }: { stopId: string }) => {
+    const [departures, setDepartures] = useState<Departure[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+    const loadDepartures = useCallback(async () => {
+        try {
+            const res = await fetch(GRAPHQL_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    query: `query GetDepartures($stopIds: [ID!]) {
+                        departures(stopIds: $stopIds, limit: 30, minutesAfter: 120) {
+                            id
+                            headsign
+                            delay
+                            isRealtime
+                            platformCode
+                            departureTime {
+                                predicted
+                                scheduled
+                            }
+                            route {
+                                name
+                                color
+                                vehicleType
+                            }
+                        }
+                    }`,
+                    variables: { stopIds: [stopId] },
+                }),
+            });
+            const json = await res.json();
+            setDepartures(json.data.departures);
+            setLastUpdated(new Date());
+        } catch {
+            // Keep existing departures on refresh failure
+        } finally {
+            setIsLoading(false);
+        }
+    }, [stopId]);
+
+    useEffect(() => {
+        loadDepartures();
+    }, [loadDepartures]);
+
+    useEffect(() => {
+        const interval = setInterval(loadDepartures, REFRESH_INTERVAL_MS);
+        return () => clearInterval(interval);
+    }, [loadDepartures]);
+
+    if (isLoading) {
+        return (
+            <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
+                Loading departures...
+            </p>
+        );
+    }
+
+    return (
+        <>
+            {lastUpdated && (
+                <p className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1 mb-4">
+                    <ClockIcon className="h-3 w-3" />
+                    Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+                </p>
+            )}
+
+            {departures.length === 0 ? (
+                <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
+                    No upcoming departures
+                </p>
+            ) : (
+                <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 px-4">
+                    {groupDepartures(departures).map((group) => (
+                        <DepartureGroupRow
+                            key={group.key}
+                            group={group}
+                        />
+                    ))}
+                </div>
+            )}
+        </>
+    );
+};

--- a/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
+++ b/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import Link from "next/link";
-import { GRAPHQL_URL } from "@/constants/api";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { graphqlFetch } from "@/utils/graphql-client";
 import { ClockIcon } from "@heroicons/react/24/outline";
+import { RouteStopList } from "../../route/[id]/RouteStopList";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type Departure = {
     id: string | null;
@@ -17,6 +24,7 @@ type Departure = {
     };
     route: {
         id: string;
+        feed: string;
         name: string | null;
         color: string | null;
         vehicleType: string;
@@ -26,6 +34,16 @@ type Departure = {
 type DepartureGroup = {
     key: string;
     departures: Departure[];
+};
+
+type DepartureQueryData = {
+    departures: Departure[];
+};
+
+type SelectedRoute = {
+    id: string;
+    feed: string;
+    name: string | null;
 };
 
 const isLightColor = (hex: string): boolean => {
@@ -73,9 +91,30 @@ const groupDepartures = (departures: Departure[]): DepartureGroup[] => {
     return groups;
 };
 
-const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
+const sortDepartures = (departures: Departure[]): Departure[] =>
+    [...departures].sort((a, b) => {
+        const aTime = new Date(a.departureTime.predicted).getTime();
+        const bTime = new Date(b.departureTime.predicted).getTime();
+
+        if (aTime !== bTime) {
+            return aTime - bTime;
+        }
+
+        return (a.route?.name ?? "").localeCompare(b.route?.name ?? "", undefined, {
+            numeric: true,
+        });
+    });
+
+const DepartureGroupRow = ({
+    group,
+    onRouteOpen,
+}: {
+    group: DepartureGroup;
+    onRouteOpen: (route: SelectedRoute) => void;
+}) => {
     const first = group.departures[0];
-    const rest = group.departures.slice(1);
+    const nextDeparture = group.departures[1];
+    const route = first.route;
     const routeColor = first.route?.color ? `#${first.route.color}` : "#6b7280";
     const routeIsLight = isLightColor(routeColor);
     const timeStr = formatDepartureTime(first.departureTime.predicted);
@@ -84,17 +123,36 @@ const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
     return (
         <div className="py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0">
             <div className="flex items-center gap-3">
-                <Link
-                    href={`/app/route/${encodeURIComponent(first.route?.id ?? "")}`}
-                    className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center hover:opacity-80 transition-opacity"
-                    style={{
-                        backgroundColor: routeColor,
-                        color: routeIsLight ? "#000" : "#fff",
-                    }}
-                    onClick={(e) => e.stopPropagation()}
-                >
-                    {first.route?.name ?? "?"}
-                </Link>
+                {route?.id ? (
+                    <button
+                        type="button"
+                        className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center hover:opacity-80 transition-opacity"
+                        style={{
+                            backgroundColor: routeColor,
+                            color: routeIsLight ? "#000" : "#fff",
+                        }}
+                        onClick={() =>
+                            onRouteOpen({
+                                id: route.id,
+                                feed: route.feed,
+                                name: route.name,
+                            })
+                        }
+                        aria-label={`Show stops for line ${route.name ?? "unknown"}`}
+                    >
+                        {route.name ?? "?"}
+                    </button>
+                ) : (
+                    <span
+                        className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center"
+                        style={{
+                            backgroundColor: routeColor,
+                            color: routeIsLight ? "#000" : "#fff",
+                        }}
+                    >
+                        {first.route?.name ?? "?"}
+                    </span>
+                )}
 
                 <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
@@ -122,16 +180,12 @@ const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
                 </div>
             </div>
 
-            {rest.length > 0 && (
-                <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1 ml-[56px]">
-                    also in{" "}
-                    {rest.map((dep, i) => (
-                        <span key={dep.id ?? `next-${i}`}>
-                            {i > 0 && ", "}
-                            {formatDepartureTime(dep.departureTime.predicted)}
-                        </span>
-                    ))}
-                </p>
+            {nextDeparture && (
+                <div className="mt-1 flex justify-end">
+                    <p className="text-right text-xs text-neutral-400 dark:text-neutral-500">
+                        also in {formatDepartureTime(nextDeparture.departureTime.predicted)}
+                    </p>
+                </div>
             )}
         </div>
     );
@@ -141,6 +195,7 @@ const REFRESH_INTERVAL_MS = 15_000;
 
 const formatRelativeTime = (date: Date): string => {
     const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (secs <= 0) return "just now";
     if (secs < 60) return `${secs}s ago`;
     const mins = Math.floor(secs / 60);
     if (mins < 60) return `${mins}m ago`;
@@ -163,46 +218,51 @@ const useRelativeTime = (date: Date | null): string => {
 export const DepartureBoard = ({ stopId }: { stopId: string }) => {
     const [departures, setDepartures] = useState<Departure[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+    const [selectedRoute, setSelectedRoute] = useState<SelectedRoute | null>(null);
     const relativeTime = useRelativeTime(lastUpdated);
+    const hasLoadedDepartures = departures.length > 0;
 
     const loadDepartures = useCallback(async () => {
         try {
-            const res = await fetch(GRAPHQL_URL, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    query: `query GetDepartures($stopIds: [ID!]) {
-                        departures(stopIds: $stopIds, limit: 30, minutesAfter: 120) {
-                            id
-                            headsign
-                            delay
-                            isRealtime
-                            platformCode
-                            departureTime {
-                                predicted
-                                scheduled
-                            }
-                            route {
-                                id
-                                name
-                                color
-                                vehicleType
-                            }
+            const data = await graphqlFetch<DepartureQueryData>(
+                `query GetDepartures($stopIds: [ID!]) {
+                    departures(stopIds: $stopIds, limit: 30, minutesAfter: 120) {
+                        id
+                        headsign
+                        delay
+                        isRealtime
+                        platformCode
+                        departureTime {
+                            predicted
+                            scheduled
                         }
-                    }`,
-                    variables: { stopIds: [stopId] },
-                }),
-            });
-            const json = await res.json();
-            setDepartures(json.data.departures);
+                        route {
+                            id
+                            feed
+                            name
+                            color
+                            vehicleType
+                        }
+                    }
+                }`,
+                { stopIds: [stopId] },
+            );
+
+            setDepartures(sortDepartures(data.departures));
             setLastUpdated(new Date());
+            setError(null);
         } catch {
-            // Keep existing departures on refresh failure
+            setError(
+                hasLoadedDepartures
+                    ? "Refresh failed. Showing the last loaded departures."
+                    : "Could not load departures",
+            );
         } finally {
             setIsLoading(false);
         }
-    }, [stopId]);
+    }, [hasLoadedDepartures, stopId]);
 
     useEffect(() => {
         loadDepartures();
@@ -215,9 +275,41 @@ export const DepartureBoard = ({ stopId }: { stopId: string }) => {
 
     if (isLoading) {
         return (
-            <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
-                Loading departures...
-            </p>
+            <>
+                <p className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1 mb-4">
+                    <ClockIcon className="h-3 w-3" />
+                    Updated just now
+                </p>
+
+                <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 px-4">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                        <div key={i} className="py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0 flex items-center gap-3">
+                            <Skeleton className="h-7 w-11 rounded" />
+                            <div className="flex-1 space-y-1.5">
+                                <Skeleton className="h-3.5 w-2/3" />
+                                <Skeleton className="h-2.5 w-1/4" />
+                            </div>
+                            <Skeleton className="h-3.5 w-12" />
+                        </div>
+                    ))}
+                </div>
+            </>
+        );
+    }
+
+    if (error && departures.length === 0) {
+        return (
+            <div className="text-center py-8">
+                <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-3">{error}</p>
+                <button
+                    type="button"
+                    onClick={loadDepartures}
+                    className="text-brandOrange text-sm font-medium hover:underline"
+                >
+                    Try again
+                </button>
+            </div>
         );
     }
 
@@ -230,6 +322,10 @@ export const DepartureBoard = ({ stopId }: { stopId: string }) => {
                 </p>
             )}
 
+            {error && departures.length > 0 && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mb-4">{error}</p>
+            )}
+
             {departures.length === 0 ? (
                 <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
                     No upcoming departures
@@ -240,10 +336,37 @@ export const DepartureBoard = ({ stopId }: { stopId: string }) => {
                         <DepartureGroupRow
                             key={group.key}
                             group={group}
+                            onRouteOpen={setSelectedRoute}
                         />
                     ))}
                 </div>
             )}
+
+            <Dialog
+                open={selectedRoute !== null}
+                onOpenChange={(isOpen) => {
+                    if (!isOpen) {
+                        setSelectedRoute(null);
+                    }
+                }}
+            >
+                <DialogContent className="sm:max-w-md">
+                    <DialogTitle className="sr-only">
+                        {selectedRoute?.name
+                            ? `Line ${selectedRoute.name} stops`
+                            : "Route stops"}
+                    </DialogTitle>
+                    <DialogDescription className="sr-only">
+                        Shows the full stop list for the selected line.
+                    </DialogDescription>
+                    {selectedRoute ? (
+                        <RouteStopList
+                            routeId={selectedRoute.id}
+                            feedId={selectedRoute.feed}
+                        />
+                    ) : null}
+                </DialogContent>
+            </Dialog>
         </>
     );
 };

--- a/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
+++ b/apps/web/src/app/app/stop/[id]/DepartureBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { GRAPHQL_URL } from "@/constants/api";
 import { ClockIcon } from "@heroicons/react/24/outline";
 
@@ -15,6 +16,7 @@ type Departure = {
         scheduled: string;
     };
     route: {
+        id: string;
         name: string | null;
         color: string | null;
         vehicleType: string;
@@ -82,15 +84,17 @@ const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
     return (
         <div className="py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0">
             <div className="flex items-center gap-3">
-                <span
-                    className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center"
+                <Link
+                    href={`/app/route/${encodeURIComponent(first.route?.id ?? "")}`}
+                    className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center hover:opacity-80 transition-opacity"
                     style={{
                         backgroundColor: routeColor,
                         color: routeIsLight ? "#000" : "#fff",
                     }}
+                    onClick={(e) => e.stopPropagation()}
                 >
                     {first.route?.name ?? "?"}
-                </span>
+                </Link>
 
                 <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
@@ -135,10 +139,32 @@ const DepartureGroupRow = ({ group }: { group: DepartureGroup }) => {
 
 const REFRESH_INTERVAL_MS = 15_000;
 
+const formatRelativeTime = (date: Date): string => {
+    const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (secs < 60) return `${secs}s ago`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    return `${Math.floor(mins / 60)}h ago`;
+};
+
+const useRelativeTime = (date: Date | null): string => {
+    const [label, setLabel] = useState(() => (date ? formatRelativeTime(date) : ""));
+
+    useEffect(() => {
+        if (!date) return;
+        setLabel(formatRelativeTime(date));
+        const interval = setInterval(() => setLabel(formatRelativeTime(date)), 1000);
+        return () => clearInterval(interval);
+    }, [date]);
+
+    return label;
+};
+
 export const DepartureBoard = ({ stopId }: { stopId: string }) => {
     const [departures, setDepartures] = useState<Departure[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+    const relativeTime = useRelativeTime(lastUpdated);
 
     const loadDepartures = useCallback(async () => {
         try {
@@ -158,6 +184,7 @@ export const DepartureBoard = ({ stopId }: { stopId: string }) => {
                                 scheduled
                             }
                             route {
+                                id
                                 name
                                 color
                                 vehicleType
@@ -199,7 +226,7 @@ export const DepartureBoard = ({ stopId }: { stopId: string }) => {
             {lastUpdated && (
                 <p className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1 mb-4">
                     <ClockIcon className="h-3 w-3" />
-                    Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+                    Updated {relativeTime}
                 </p>
             )}
 

--- a/apps/web/src/app/app/stop/[id]/default.tsx
+++ b/apps/web/src/app/app/stop/[id]/default.tsx
@@ -1,0 +1,1 @@
+export { default } from "./page";

--- a/apps/web/src/app/app/stop/[id]/page.tsx
+++ b/apps/web/src/app/app/stop/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { GRAPHQL_URL } from "@/constants/api";
+import { graphqlFetch } from "@/utils/graphql-client";
 import { getTitle } from "@/utils/metadata.utils";
 import { ArrowLeftIcon } from "@heroicons/react/24/outline";
 import { DepartureBoard } from "./DepartureBoard";
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 
 type Stop = {
     id: string;
+    feed: string | null;
     name: string;
     avgLatitude: number;
     avgLongitude: number;
@@ -15,24 +16,21 @@ type Stop = {
 
 const fetchStop = async (id: string): Promise<Stop | null> => {
     try {
-        const res = await fetch(GRAPHQL_URL, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                query: `query GetStop($id: ID!) {
-                    stop(id: $id) {
-                        id
-                        name
-                        avgLatitude
-                        avgLongitude
-                    }
-                }`,
-                variables: { id },
-            }),
-            next: { revalidate: 3600 },
-        });
-        const json = await res.json();
-        return json.data?.stop ?? null;
+        const data = await graphqlFetch<{ stop: Stop | null }>(
+            `query GetStop($id: ID!) {
+                stop(id: $id) {
+                    id
+                    feed
+                    name
+                    avgLatitude
+                    avgLongitude
+                }
+            }`,
+            { id },
+            { next: { revalidate: 3600 } },
+        );
+
+        return data.stop;
     } catch {
         return null;
     }

--- a/apps/web/src/app/app/stop/[id]/page.tsx
+++ b/apps/web/src/app/app/stop/[id]/page.tsx
@@ -1,245 +1,63 @@
-"use client";
-
-import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { notFound } from "next/navigation";
 import { GRAPHQL_URL } from "@/constants/api";
-import { ArrowLeftIcon, ClockIcon } from "@heroicons/react/24/outline";
-
-type Route = {
-    name: string | null;
-    color: string | null;
-    vehicleType: string;
-};
-
-type Platform = {
-    id: string;
-    name: string;
-    code: string | null;
-    routes: Route[];
-};
+import { getTitle } from "@/utils/metadata.utils";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { DepartureBoard } from "./DepartureBoard";
+import type { Metadata } from "next";
 
 type Stop = {
     id: string;
     name: string;
     avgLatitude: number;
     avgLongitude: number;
-    platforms: Platform[];
 };
 
-type Departure = {
-    id: string | null;
-    headsign: string | null;
-    delay: number | null;
-    isRealtime: boolean;
-    platformCode: string | null;
-    departureTime: {
-        predicted: string;
-        scheduled: string;
-    };
-    route: {
-        name: string | null;
-        color: string | null;
-        vehicleType: string;
-    } | null;
-};
-
-const graphqlFetch = async <T,>(query: string, variables?: Record<string, unknown>): Promise<T> => {
-    const res = await fetch(GRAPHQL_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query, variables }),
-    });
-    const json = await res.json();
-    return json.data;
-};
-
-const isLightColor = (hex: string): boolean => {
-    const c = hex.replace("#", "");
-    const r = Number.parseInt(c.substring(0, 2), 16);
-    const g = Number.parseInt(c.substring(2, 4), 16);
-    const b = Number.parseInt(c.substring(4, 6), 16);
-    return (r * 299 + g * 587 + b * 114) / 1000 > 150;
-};
-
-const formatDepartureTime = (isoString: string): string => {
-    const date = new Date(isoString);
-    const now = new Date();
-    const diffMs = date.getTime() - now.getTime();
-    const diffMin = Math.round(diffMs / 60000);
-
-    if (diffMin <= 0) return "now";
-    if (diffMin < 60) return `${diffMin} min`;
-
-    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-};
-
-const formatDelay = (delaySeconds: number): string => {
-    const minutes = Math.round(delaySeconds / 60);
-    if (minutes === 0) return "";
-    return minutes > 0 ? `+${minutes}` : `${minutes}`;
-};
-
-const DepartureRow = ({ departure }: { departure: Departure }) => {
-    const routeColor = departure.route?.color ? `#${departure.route.color}` : "#6b7280";
-    const routeIsLight = isLightColor(routeColor);
-    const timeStr = formatDepartureTime(departure.departureTime.predicted);
-    const delayStr = departure.delay ? formatDelay(departure.delay) : "";
-
-    return (
-        <div className="flex items-center gap-3 py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0">
-            <span
-                className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center"
-                style={{
-                    backgroundColor: routeColor,
-                    color: routeIsLight ? "#000" : "#fff",
-                }}
-            >
-                {departure.route?.name ?? "?"}
-            </span>
-
-            <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
-                    {departure.headsign ?? "Unknown destination"}
-                </p>
-                {departure.platformCode && (
-                    <p className="text-xs text-neutral-400 dark:text-neutral-500">
-                        Platform {departure.platformCode}
-                    </p>
-                )}
-            </div>
-
-            <div className="text-right flex items-center gap-1.5">
-                <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100 tabular-nums">
-                    {timeStr}
-                </span>
-                {delayStr && (
-                    <span className="text-xs text-red-500 font-medium tabular-nums">
-                        {delayStr}
-                    </span>
-                )}
-                {departure.isRealtime && (
-                    <span className="h-2 w-2 rounded-full bg-green-500 flex-shrink-0" title="Real-time" />
-                )}
-            </div>
-        </div>
-    );
-};
-
-const REFRESH_INTERVAL_MS = 15_000;
-
-export default function StopDetailPage() {
-    const params = useParams<{ id: string }>();
-    const stopId = params?.id ?? "";
-
-    const [stop, setStop] = useState<Stop | null>(null);
-    const [departures, setDepartures] = useState<Departure[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-
-    const loadStop = useCallback(async () => {
-        try {
-            const data = await graphqlFetch<{ stop: Stop | null }>(
-                `query GetStop($id: ID!) {
+const fetchStop = async (id: string): Promise<Stop | null> => {
+    try {
+        const res = await fetch(GRAPHQL_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                query: `query GetStop($id: ID!) {
                     stop(id: $id) {
                         id
                         name
                         avgLatitude
                         avgLongitude
-                        platforms {
-                            id
-                            name
-                            code
-                            routes {
-                                name
-                                color
-                                vehicleType
-                            }
-                        }
                     }
                 }`,
-                { id: stopId },
-            );
-            setStop(data.stop);
-            if (!data.stop) {
-                setError("Stop not found");
-            }
-        } catch {
-            setError("Failed to load stop");
-        }
-    }, [stopId]);
-
-    const loadDepartures = useCallback(async () => {
-        try {
-            const data = await graphqlFetch<{ departures: Departure[] }>(
-                `query GetDepartures($stopIds: [ID!]) {
-                    departures(stopIds: $stopIds, limit: 30, minutesAfter: 120) {
-                        id
-                        headsign
-                        delay
-                        isRealtime
-                        platformCode
-                        departureTime {
-                            predicted
-                            scheduled
-                        }
-                        route {
-                            name
-                            color
-                            vehicleType
-                        }
-                    }
-                }`,
-                { stopIds: [stopId] },
-            );
-            setDepartures(data.departures);
-            setLastUpdated(new Date());
-        } catch {
-            // Keep existing departures on refresh failure
-        }
-    }, [stopId]);
-
-    useEffect(() => {
-        const init = async () => {
-            setIsLoading(true);
-            await loadStop();
-            await loadDepartures();
-            setIsLoading(false);
-        };
-        init();
-    }, [loadStop, loadDepartures]);
-
-    useEffect(() => {
-        const interval = setInterval(loadDepartures, REFRESH_INTERVAL_MS);
-        return () => clearInterval(interval);
-    }, [loadDepartures]);
-
-    if (isLoading) {
-        return (
-            <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
-                <p className="text-neutral-500 dark:text-neutral-400 text-center py-12">
-                    Loading...
-                </p>
-            </main>
-        );
+                variables: { id },
+            }),
+            next: { revalidate: 3600 },
+        });
+        const json = await res.json();
+        return json.data?.stop ?? null;
+    } catch {
+        return null;
     }
+};
 
-    if (error || !stop) {
-        return (
-            <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
-                <Link
-                    href="/app"
-                    className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
-                >
-                    <ArrowLeftIcon className="h-4 w-4" />
-                    Back
-                </Link>
-                <p className="text-neutral-500 dark:text-neutral-400 text-center py-12">
-                    {error ?? "Stop not found"}
-                </p>
-            </main>
-        );
+type Props = {
+    params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { id } = await params;
+    const stop = await fetchStop(decodeURIComponent(id));
+
+    return {
+        title: getTitle(stop?.name ?? "Stop"),
+        description: stop ? `Real-time departures from ${stop.name}` : "Stop not found",
+    };
+}
+
+export default async function StopDetailPage({ params }: Props) {
+    const { id } = await params;
+    const stop = await fetchStop(decodeURIComponent(id));
+
+    if (!stop) {
+        notFound();
     }
 
     return (
@@ -252,29 +70,9 @@ export default function StopDetailPage() {
                 Back
             </Link>
 
-            <h1 className="text-2xl font-bold mb-1">{stop.name}</h1>
+            <h1 className="text-2xl font-bold mb-4">{stop.name}</h1>
 
-            {lastUpdated && (
-                <p className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1 mb-6">
-                    <ClockIcon className="h-3 w-3" />
-                    Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
-                </p>
-            )}
-
-            {departures.length === 0 ? (
-                <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
-                    No upcoming departures
-                </p>
-            ) : (
-                <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 px-4">
-                    {departures.map((departure, i) => (
-                        <DepartureRow
-                            key={departure.id ?? `dep-${i}`}
-                            departure={departure}
-                        />
-                    ))}
-                </div>
-            )}
+            <DepartureBoard stopId={stop.id} />
         </main>
     );
 }

--- a/apps/web/src/app/app/stop/[id]/page.tsx
+++ b/apps/web/src/app/app/stop/[id]/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { GRAPHQL_URL } from "@/constants/api";
+import { ArrowLeftIcon, ClockIcon } from "@heroicons/react/24/outline";
+
+type Route = {
+    name: string | null;
+    color: string | null;
+    vehicleType: string;
+};
+
+type Platform = {
+    id: string;
+    name: string;
+    code: string | null;
+    routes: Route[];
+};
+
+type Stop = {
+    id: string;
+    name: string;
+    avgLatitude: number;
+    avgLongitude: number;
+    platforms: Platform[];
+};
+
+type Departure = {
+    id: string | null;
+    headsign: string | null;
+    delay: number | null;
+    isRealtime: boolean;
+    platformCode: string | null;
+    departureTime: {
+        predicted: string;
+        scheduled: string;
+    };
+    route: {
+        name: string | null;
+        color: string | null;
+        vehicleType: string;
+    } | null;
+};
+
+const graphqlFetch = async <T,>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+    const res = await fetch(GRAPHQL_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query, variables }),
+    });
+    const json = await res.json();
+    return json.data;
+};
+
+const isLightColor = (hex: string): boolean => {
+    const c = hex.replace("#", "");
+    const r = Number.parseInt(c.substring(0, 2), 16);
+    const g = Number.parseInt(c.substring(2, 4), 16);
+    const b = Number.parseInt(c.substring(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 > 150;
+};
+
+const formatDepartureTime = (isoString: string): string => {
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const diffMin = Math.round(diffMs / 60000);
+
+    if (diffMin <= 0) return "now";
+    if (diffMin < 60) return `${diffMin} min`;
+
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+};
+
+const formatDelay = (delaySeconds: number): string => {
+    const minutes = Math.round(delaySeconds / 60);
+    if (minutes === 0) return "";
+    return minutes > 0 ? `+${minutes}` : `${minutes}`;
+};
+
+const DepartureRow = ({ departure }: { departure: Departure }) => {
+    const routeColor = departure.route?.color ? `#${departure.route.color}` : "#6b7280";
+    const routeIsLight = isLightColor(routeColor);
+    const timeStr = formatDepartureTime(departure.departureTime.predicted);
+    const delayStr = departure.delay ? formatDelay(departure.delay) : "";
+
+    return (
+        <div className="flex items-center gap-3 py-3 border-b border-neutral-100 dark:border-neutral-800 last:border-b-0">
+            <span
+                className="inline-flex items-center justify-center px-2 py-1 rounded font-bold text-sm min-w-[44px] text-center"
+                style={{
+                    backgroundColor: routeColor,
+                    color: routeIsLight ? "#000" : "#fff",
+                }}
+            >
+                {departure.route?.name ?? "?"}
+            </span>
+
+            <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
+                    {departure.headsign ?? "Unknown destination"}
+                </p>
+                {departure.platformCode && (
+                    <p className="text-xs text-neutral-400 dark:text-neutral-500">
+                        Platform {departure.platformCode}
+                    </p>
+                )}
+            </div>
+
+            <div className="text-right flex items-center gap-1.5">
+                <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100 tabular-nums">
+                    {timeStr}
+                </span>
+                {delayStr && (
+                    <span className="text-xs text-red-500 font-medium tabular-nums">
+                        {delayStr}
+                    </span>
+                )}
+                {departure.isRealtime && (
+                    <span className="h-2 w-2 rounded-full bg-green-500 flex-shrink-0" title="Real-time" />
+                )}
+            </div>
+        </div>
+    );
+};
+
+const REFRESH_INTERVAL_MS = 15_000;
+
+export default function StopDetailPage() {
+    const params = useParams<{ id: string }>();
+    const stopId = params?.id ?? "";
+
+    const [stop, setStop] = useState<Stop | null>(null);
+    const [departures, setDepartures] = useState<Departure[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+    const loadStop = useCallback(async () => {
+        try {
+            const data = await graphqlFetch<{ stop: Stop | null }>(
+                `query GetStop($id: ID!) {
+                    stop(id: $id) {
+                        id
+                        name
+                        avgLatitude
+                        avgLongitude
+                        platforms {
+                            id
+                            name
+                            code
+                            routes {
+                                name
+                                color
+                                vehicleType
+                            }
+                        }
+                    }
+                }`,
+                { id: stopId },
+            );
+            setStop(data.stop);
+            if (!data.stop) {
+                setError("Stop not found");
+            }
+        } catch {
+            setError("Failed to load stop");
+        }
+    }, [stopId]);
+
+    const loadDepartures = useCallback(async () => {
+        try {
+            const data = await graphqlFetch<{ departures: Departure[] }>(
+                `query GetDepartures($stopIds: [ID!]) {
+                    departures(stopIds: $stopIds, limit: 30, minutesAfter: 120) {
+                        id
+                        headsign
+                        delay
+                        isRealtime
+                        platformCode
+                        departureTime {
+                            predicted
+                            scheduled
+                        }
+                        route {
+                            name
+                            color
+                            vehicleType
+                        }
+                    }
+                }`,
+                { stopIds: [stopId] },
+            );
+            setDepartures(data.departures);
+            setLastUpdated(new Date());
+        } catch {
+            // Keep existing departures on refresh failure
+        }
+    }, [stopId]);
+
+    useEffect(() => {
+        const init = async () => {
+            setIsLoading(true);
+            await loadStop();
+            await loadDepartures();
+            setIsLoading(false);
+        };
+        init();
+    }, [loadStop, loadDepartures]);
+
+    useEffect(() => {
+        const interval = setInterval(loadDepartures, REFRESH_INTERVAL_MS);
+        return () => clearInterval(interval);
+    }, [loadDepartures]);
+
+    if (isLoading) {
+        return (
+            <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+                <p className="text-neutral-500 dark:text-neutral-400 text-center py-12">
+                    Loading...
+                </p>
+            </main>
+        );
+    }
+
+    if (error || !stop) {
+        return (
+            <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+                <Link
+                    href="/app"
+                    className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
+                >
+                    <ArrowLeftIcon className="h-4 w-4" />
+                    Back
+                </Link>
+                <p className="text-neutral-500 dark:text-neutral-400 text-center py-12">
+                    {error ?? "Stop not found"}
+                </p>
+            </main>
+        );
+    }
+
+    return (
+        <main className="max-w-screen-sm mx-auto px-4 mt-24 pb-12 text-black dark:text-white">
+            <Link
+                href="/app"
+                className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6"
+            >
+                <ArrowLeftIcon className="h-4 w-4" />
+                Back
+            </Link>
+
+            <h1 className="text-2xl font-bold mb-1">{stop.name}</h1>
+
+            {lastUpdated && (
+                <p className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1 mb-6">
+                    <ClockIcon className="h-3 w-3" />
+                    Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+                </p>
+            )}
+
+            {departures.length === 0 ? (
+                <p className="text-neutral-500 dark:text-neutral-400 text-sm py-8 text-center">
+                    No upcoming departures
+                </p>
+            ) : (
+                <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 px-4">
+                    {departures.map((departure, i) => (
+                        <DepartureRow
+                            key={departure.id ?? `dep-${i}`}
+                            departure={departure}
+                        />
+                    ))}
+                </div>
+            )}
+        </main>
+    );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout({
             </head>
 
             <body className={poppins.className}>
-                <div className="dark:bg-black">
+                <div className="dark:bg-black min-h-screen">
                     <Navbar variant="transparent" />
 
                     {children}

--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -56,6 +56,8 @@ export const Navbar = (props: Props) => {
                     <div className="gap-12 sm:flex hidden">
                         <NavbarLink href={"/"}>About</NavbarLink>
 
+                        <NavbarLink href={"/app"}>App</NavbarLink>
+
                         <NavbarLink href={"/map"}>Map</NavbarLink>
 
                         <NavbarLink href={SOURCE_CODE_URL} target="_blank">

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { twMerge } from "@/utils/tw-merge.utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={twMerge("fixed inset-0 z-50 bg-black/50 backdrop-blur-sm", className)}
+        {...props}
+    />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={twMerge(
+                "fixed inset-x-0 bottom-0 z-50 max-h-[85vh] w-full overflow-y-auto rounded-t-2xl border border-neutral-200 bg-white p-6 shadow-xl outline-none dark:border-neutral-700 dark:bg-neutral-900 sm:left-1/2 sm:top-1/2 sm:w-[min(100%-2rem,28rem)] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl",
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full p-1 text-neutral-500 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">
+                <XMarkIcon className="h-5 w-5" />
+                <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+    </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={twMerge("flex flex-col gap-1.5 text-left", className)} {...props} />
+);
+
+const DialogTitle = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+        ref={ref}
+        className={twMerge("text-lg font-semibold text-neutral-950 dark:text-neutral-50", className)}
+        {...props}
+    />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+        ref={ref}
+        className={twMerge("text-sm text-neutral-500 dark:text-neutral-400", className)}
+        {...props}
+    />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogOverlay,
+    DialogPortal,
+    DialogTitle,
+    DialogTrigger,
+};

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,3 @@
+export const Skeleton = ({ className }: { className?: string }) => (
+    <div className={`animate-pulse rounded bg-neutral-200 dark:bg-neutral-700 ${className ?? ""}`} />
+);

--- a/apps/web/src/constants/api.ts
+++ b/apps/web/src/constants/api.ts
@@ -1,4 +1,5 @@
-export const API_URL = "https://api.metronow.dev";
+export const API_URL =
+    process.env.NEXT_PUBLIC_API_URL ?? "https://api.metronow.dev";
 
 export const APPSTORE_URL =
     "https://apps.apple.com/cz/app/metro-now/id6504659402";

--- a/apps/web/src/utils/app-paths.ts
+++ b/apps/web/src/utils/app-paths.ts
@@ -1,0 +1,5 @@
+export const getStopPath = (feedId: string, stopId: string): string =>
+    `/app/stop/${encodeURIComponent(feedId)}/${encodeURIComponent(stopId)}`;
+
+export const getRoutePath = (feedId: string, routeId: string): string =>
+    `/app/route/${encodeURIComponent(feedId)}/${encodeURIComponent(routeId)}`;

--- a/apps/web/src/utils/graphql-client.ts
+++ b/apps/web/src/utils/graphql-client.ts
@@ -1,0 +1,44 @@
+import { GRAPHQL_URL } from "@/constants/api";
+
+type GraphqlResponse<T> = {
+    data?: T;
+    errors?: { message?: string }[];
+};
+
+type GraphqlFetchInit = RequestInit & {
+    next?: {
+        revalidate?: number | false;
+        tags?: string[];
+    };
+};
+
+export const graphqlFetch = async <T>(
+    query: string,
+    variables?: Record<string, unknown>,
+    init?: GraphqlFetchInit,
+): Promise<T> => {
+    const response = await fetch(GRAPHQL_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...init?.headers,
+        },
+        body: JSON.stringify({ query, variables }),
+        ...init,
+    });
+
+    const json = (await response.json()) as GraphqlResponse<T>;
+
+    if (!response.ok || json.errors?.length) {
+        throw new Error(
+            json.errors?.[0]?.message ??
+                `GraphQL request failed with ${response.status}`,
+        );
+    }
+
+    if (!json.data) {
+        throw new Error("GraphQL response did not include data");
+    }
+
+    return json.data;
+};

--- a/apps/web/src/utils/metadata.utils.ts
+++ b/apps/web/src/utils/metadata.utils.ts
@@ -3,5 +3,5 @@ export const getTitle = (title?: string | null) => {
         return "Metro Now";
     }
 
-    `${title} | Metro Now`;
+    return `${title} | Metro Now`;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@next/mdx':
         specifier: ^14.2.26
         version: 14.2.26(@mdx-js/react@2.3.0(react@18.3.1))
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1880,6 +1883,177 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@redis/client@5.11.0':
     resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
     engines: {node: '>= 18'}
@@ -2488,6 +2662,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -3242,6 +3420,9 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -3796,6 +3977,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -5594,6 +5779,36 @@ packages:
       maplibre-gl:
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -6535,6 +6750,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -8340,6 +8575,149 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.20)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.20)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
   '@redis/client@5.11.0':
     dependencies:
       cluster-key-slot: 1.1.2
@@ -8943,6 +9321,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -9747,6 +10129,8 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
+  detect-node-es@1.1.0: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -10539,6 +10923,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -12893,6 +13279,33 @@ snapshots:
     optionalDependencies:
       mapbox-gl: 3.11.0
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.20)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.20)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  react-remove-scroll@2.7.2(@types/react@18.3.20)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.20)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.20)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.20)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.20)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  react-style-singleton@2.2.3(@types/react@18.3.20)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -14111,6 +14524,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@18.3.20)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.20
+
+  use-sidecar@1.1.3(@types/react@18.3.20)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.20
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
- Search stops via GraphQL searchStops query with debounced input
- Geolocation-based nearby stops sorted by distance
- Stop detail page with live departure board (auto-refreshes every 15s)
- Route badges with colors sorted by vehicle type
- Added App link to navbar